### PR TITLE
Match kube go version requirements

### DIFF
--- a/make/lib/golang.mk
+++ b/make/lib/golang.mk
@@ -17,7 +17,7 @@ GOFMT_FLAGS ?=-s -l
 GOLINT ?=golint
 
 go_version :=$(shell $(GO) version | sed -E -e 's/.*go([0-9]+.[0-9]+.[0-9]+).*/\1/')
-GO_REQUIRED_MIN_VERSION ?=1.13.5
+GO_REQUIRED_MIN_VERSION ?=1.13.4
 ifneq "$(GO_REQUIRED_MIN_VERSION)" ""
 $(call require_minimal_version,$(GO),GO_REQUIRED_MIN_VERSION,$(go_version))
 endif


### PR DESCRIPTION
kube requires go 1.13.4 https://github.com/kubernetes/kubernetes/blob/7a1eaa1/hack/lib/golang.sh#L470

/cc @mfojtik 