### PR TITLE
Fix verify-deps exit code

### DIFF
--- a/make/targets/openshift/deps-gomod.mk
+++ b/make/targets/openshift/deps-gomod.mk
@@ -15,14 +15,14 @@ endef
 verify-deps: tmp_dir:=$(shell mktemp -d)
 verify-deps:
 	$(call restore-deps,$(tmp_dir))
-	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.mod || echo '`go.mod` content is incorrect - did you run `go mod tidy`?'
-	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.sum || echo '`go.sum` content is incorrect - did you run `go mod tidy`?'
+	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.mod || echo '`go.mod` content is incorrect - did you run `go mod tidy`?' && false
+	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.sum || echo '`go.sum` content is incorrect - did you run `go mod tidy`?' && false
 	@echo $(deps_diff) '$(tmp_dir)'/{current,updated}/deps.diff
 	@     $(deps_diff) '$(tmp_dir)'/{current,updated}/deps.diff || ( \
 		echo "ERROR: Content of 'vendor/' directory doesn't match 'go.mod' configuration and the overrides in 'deps.diff'!" && \
 		echo 'Did you run `go mod vendor`?' && \
 		echo "If this is an intentional change (a carry patch) please update the 'deps.diff' using 'make update-deps-overrides'." && \
-		exit 1 \
+		false \
 	)
 .PHONY: verify-deps
 
@@ -39,4 +39,3 @@ update-deps-overrides:
 include $(addprefix $(self_dir), \
 	../../lib/golang.mk \
 )
-


### PR DESCRIPTION
/cc @mfojtik 

@openshift/sig-master @openshift/openshift-team-etcd @openshift/openshift-team-developer-experience I recommend bumping build-machinery-go when you bump your next dep, as this is limited to checking dependencies, immediate bump isn't required given you'd need special BZ