### PR TITLE
Fix permission error when running "make update-generated"

### DIFF
--- a/make/targets/openshift/codegen.mk
+++ b/make/targets/openshift/codegen.mk
@@ -1,3 +1,5 @@
+SHELL :=/bin/bash
+
 CODEGEN_PKG ?=./vendor/k8s.io/code-generator/
 CODEGEN_GENERATORS ?=all
 CODEGEN_OUTPUT_BASE ?=../../..
@@ -9,6 +11,7 @@ CODEGEN_OUTPUT_PACKAGE ?=$(error CODEGEN_OUTPUT_PACKAGE is required)
 
 define run-codegen
 $(CODEGEN_PKG)/generate-groups.sh \
+	"$(SHELL)" \
 	"$(CODEGEN_GENERATORS)" \
 	"$(CODEGEN_OUTPUT_PACKAGE)" \
 	"$(CODEGEN_API_PACKAGE)" \


### PR DESCRIPTION
I don't know if this is the right way to fix this, so feel free to close if it's not.

I'm using `codegen.mk` and I get the following error when I run `make update-generated`:

`/bin/sh: ./vendor/k8s.io/code-generator//generate-groups.sh: Permission denied`

Please check the commit message for more details.