### PR TITLE
Fix permission error in codegen.mk

### DIFF
--- a/make/targets/openshift/codegen.mk
+++ b/make/targets/openshift/codegen.mk
@@ -1,3 +1,5 @@
+SHELL :=/bin/bash
+
 CODEGEN_PKG ?=./vendor/k8s.io/code-generator/
 CODEGEN_GENERATORS ?=all
 CODEGEN_OUTPUT_BASE ?=../../..
@@ -8,16 +10,16 @@ CODEGEN_GROUPS_VERSION ?=$(error CODEGEN_GROUPS_VERSION is required)
 CODEGEN_OUTPUT_PACKAGE ?=$(error CODEGEN_OUTPUT_PACKAGE is required)
 
 define run-codegen
-$(CODEGEN_PKG)/generate-groups.sh \
+	"$(SHELL)" \
+	"$(CODEGEN_PKG)/generate-groups.sh" \
 	"$(CODEGEN_GENERATORS)" \
 	"$(CODEGEN_OUTPUT_PACKAGE)" \
 	"$(CODEGEN_API_PACKAGE)" \
 	"$(CODEGEN_GROUPS_VERSION)" \
-    --output-base $(CODEGEN_OUTPUT_BASE) \
-    --go-header-file $(CODEGEN_GO_HEADER_FILE) \
-    $1
+	--output-base $(CODEGEN_OUTPUT_BASE) \
+	--go-header-file $(CODEGEN_GO_HEADER_FILE) \
+	$1
 endef
-
 
 verify-codegen:
 	$(call run-codegen,--verify-only)


### PR DESCRIPTION
I don't know if this is the right way to fix this, so feel free to close if it's not.

I'm using `codegen.mk` and I get the following error when I run `make update-generated`:

`/bin/sh: ./vendor/k8s.io/code-generator//generate-groups.sh: Permission denied`

Please check the commit message for more details.