### PR TITLE
crd-schema-gen: verify against output instead of manifests

### DIFF
--- a/make/targets/openshift/crd-schema-gen.mk
+++ b/make/targets/openshift/crd-schema-gen.mk
@@ -42,7 +42,7 @@ update-codegen-crds: update-codegen-crds-$(1)
 verify-codegen-crds-$(1): VERIFY_CODEGEN_CRD_TMP_DIR:=$$(shell mktemp -d)
 verify-codegen-crds-$(1): ensure-controller-gen ensure-yq
 	$(call run-crd-gen,$(2),$(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR))
-	$$(foreach p,$$(wildcard $(3)/*.crd.yaml),$$(call diff-file,$$(p),$$(subst $(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR),$$(p))))
+	$$(foreach p,$$(wildcard $(4)/*.crd.yaml),$$(call diff-file,$$(p),$$(subst $(4),$$(VERIFY_CODEGEN_CRD_TMP_DIR),$$(p))))
 .PHONY: verify-codegen-crds-$(1)
 
 verify-codegen-crds: verify-codegen-crds-$(1)


### PR DESCRIPTION
The verify-codegen-crds target should compare the CRDs generating in the temp directory against the CRDs in the output directory rather than against the CRDs in the manifests directory.