### PR TITLE
Loosen extension check for CRD verify script

### DIFF
--- a/make/targets/openshift/crd-schema-gen.mk
+++ b/make/targets/openshift/crd-schema-gen.mk
@@ -42,7 +42,7 @@ update-codegen-crds: update-codegen-crds-$(1)
 verify-codegen-crds-$(1): VERIFY_CODEGEN_CRD_TMP_DIR:=$$(shell mktemp -d)
 verify-codegen-crds-$(1): ensure-controller-gen ensure-yq
 	$(call run-crd-gen,$(2),$(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR))
-	$$(foreach p,$$(wildcard $(3)/*.crd.yaml),$$(call diff-file,$$(p),$$(subst $(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR),$$(p))))
+	$$(foreach p,$$(wildcard $(3)/*crd.yaml),$$(call diff-file,$$(p),$$(subst $(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR),$$(p))))
 .PHONY: verify-codegen-crds-$(1)
 
 verify-codegen-crds: verify-codegen-crds-$(1)


### PR DESCRIPTION
The script to verify CRD codegen checks diffs only against files that
end in exactly `.crd.yaml`. This loosens that to just `crd.yaml` (with
no leading `.`) to ensure all CRDs are captured.

There are very few English words ending in `crd`, so I don't think there
is a risk of this conflicting.