### PR TITLE
WIP: *: Document targets in 'make help'

### DIFF
--- a/make/targets/help.mk
+++ b/make/targets/help.mk
@@ -1,6 +1,4 @@
-help:
+help: ## Print help for available make targets.
 	$(info The following make targets are available:)
-	@$(MAKE) -f $(firstword $(MAKEFILE_LIST)) --print-data-base --question no-such-target 2>&1 | grep -v 'no-such-target' | \
-	grep -v -e '^no-such-target' -e '^makefile' | \
-	awk '/^[^.%][-A-Za-z0-9_]*:/	{ print substr($$1, 1, length($$1)-1) }' | sort -u
+	@sed -n 's/^\([a-zA-Z_\-]*\): .*## \(.*\)/  \1\t\2/p' $(MAKEFILE_LIST) | sort
 .PHONY: help


### PR DESCRIPTION
Before:

```console
$ make help
The following make targets are available:
all
help
Makefile
update
update-makefiles
verify
verify-makefiles
```

which left users guessing about the intended semantics (e.g. what does `make Makefile` do?).  Now:

```console
$ make help
The following make targets are available:
  help	Print help for available make targets.
  FIXME: document more stuff
```

WIP because I need to add docs to the other public targets.  Floating now to get a feel for whether this PR is likely to get a green light, before putting in that time.

Both my [`sed`][1] and [`sort`][2] usages are POSIX-compatible.

[1]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sed.html
[2]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sort.html