### PR TITLE
Bump min golang version to 1.14.4 for kubernetes 1.19

### DIFF
--- a/make/lib/golang.mk
+++ b/make/lib/golang.mk
@@ -17,7 +17,7 @@ GOFMT_FLAGS ?=-s -l
 GOLINT ?=golint
 
 go_version :=$(shell $(GO) version | sed -E -e 's/.*go([0-9]+.[0-9]+.[0-9]+).*/\1/')
-GO_REQUIRED_MIN_VERSION ?=1.13.4
+GO_REQUIRED_MIN_VERSION ?=1.14.4
 ifneq "$(GO_REQUIRED_MIN_VERSION)" ""
 $(call require_minimal_version,$(GO),GO_REQUIRED_MIN_VERSION,$(go_version))
 endif


### PR DESCRIPTION
Requires https://github.com/openshift/release/pull/10562

https://github.com/kubernetes/kubernetes/blob/05ffc95/hack/lib/golang.sh#L470

/cc @sttts @marun 

@openshift/sig-master you get it when you bump