### PR TITLE
Add *.yaml-patch support for CRDs + bump to controller-gen v0.2.5

### DIFF
--- a/make/examples/multiple-binaries/Makefile.test
+++ b/make/examples/multiple-binaries/Makefile.test
@@ -59,7 +59,7 @@ test-codegen:
 
 	$(MAKE) update-codegen-crds
 	$(MAKE) verify-codegen-crds
-	cp -r ./testing/manifests/initial/*.crd.yaml-merge-patch ./manifests/
+	cp -r ./testing/manifests/initial/*.crd.yaml{-merge-patch,-patch} ./manifests/
 	! diff -Naup ./testing/manifests/initial/ ./manifests/ 2>/dev/null 1>&2
 	diff -Naup ./testing/manifests/updated/ ./manifests/
 

--- a/make/examples/multiple-binaries/Makefile.test.log
+++ b/make/examples/multiple-binaries/Makefile.test.log
@@ -21,6 +21,8 @@ rm -f '_output/tools/bin/controller-gen'
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f '_output/tools/bin/yq'
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
+rm -f '_output/tools/bin/yaml-patch'
+if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
 [[ ! -f ./openshift ]]
@@ -32,6 +34,8 @@ if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
 rm -f '_output/tools/bin/controller-gen'
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f '_output/tools/bin/yq'
+if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
+rm -f '_output/tools/bin/yaml-patch'
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
@@ -59,6 +63,8 @@ rm -f '_output/tools/bin/controller-gen'
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f '_output/tools/bin/yq'
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
+rm -f '_output/tools/bin/yaml-patch'
+if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
 [[ ! -d ./_output/ ]] || (ls -l ./_output/ && false)
@@ -69,6 +75,8 @@ if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
 rm -f '_output/tools/bin/controller-gen'
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f '_output/tools/bin/yq'
+if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
+rm -f '_output/tools/bin/yaml-patch'
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
@@ -85,6 +93,8 @@ rm -f '_output/tools/bin/controller-gen'
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f '_output/tools/bin/yq'
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
+rm -f '_output/tools/bin/yaml-patch'
+if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
 [[ ! -d ./_output/ ]] || (ls -l ./_output/ && false)
@@ -95,6 +105,8 @@ if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
 rm -f '_output/tools/bin/controller-gen'
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f '_output/tools/bin/yq'
+if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
+rm -f '_output/tools/bin/yaml-patch'
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
@@ -109,6 +121,10 @@ Installing yq into '_output/tools/bin/yq'
 mkdir -p '_output/tools/bin/'
 curl -s -f -L https://github.com/mikefarah/yq/releases/download/2.4.0/yq_linux_amd64 -o '_output/tools/bin/yq'
 chmod +x '_output/tools/bin/yq';
+Installing yaml-patch into '_output/tools/bin/yaml-patch'
+mkdir -p '_output/tools/bin/'
+curl -s -f -L https://github.com/krishicks/yaml-patch/releases/download/v0.0.10/yaml_patch_linux -o '_output/tools/bin/yaml-patch'
+chmod +x '_output/tools/bin/yaml-patch';
 --- ./manifests/operator.openshift.io_myotheroperatorresources.crd.yaml
 @@ -9,6 +9,40 @@ spec:
      kind: MyOtherOperatorResource
@@ -155,13 +171,17 @@ make[2]: *** [verify-codegen-crds-manifests] Error 1
 make update-codegen-crds
 Using existing controller-gen from "_output/tools/bin/controller-gen"
 Using existing yq from "_output/tools/bin/yq"
+Using existing yaml-patch from "_output/tools/bin/yaml-patch"
 '_output/tools/bin/controller-gen' schemapatch:manifests="./manifests" paths="./pkg/apis/v1;./pkg/apis/v1beta1" output:dir="./manifests"
 _output/tools/bin/yq m -i -x './manifests/operator.openshift.io_myotheroperatorresources.crd.yaml' './manifests/operator.openshift.io_myotheroperatorresources.crd.yaml-merge-patch'
 _output/tools/bin/yq m -i -x './manifests/operator.openshift.io_myoperatorresources.crd.yaml' './manifests/operator.openshift.io_myoperatorresources.crd.yaml-merge-patch'
+_output/tools/bin/yaml-patch -o './manifests/operator.openshift.io_myv1resources.crd.yaml-patch' < './manifests/operator.openshift.io_myv1resources.crd.yaml' > './manifests/operator.openshift.io_myv1resources.crd.yaml.patched'
+mv './manifests/operator.openshift.io_myv1resources.crd.yaml.patched' './manifests/operator.openshift.io_myv1resources.crd.yaml'
 make verify-codegen-crds
 Using existing controller-gen from "_output/tools/bin/controller-gen"
 Using existing yq from "_output/tools/bin/yq"
-cp -r ./testing/manifests/initial/*.crd.yaml-merge-patch ./manifests/
+Using existing yaml-patch from "_output/tools/bin/yaml-patch"
+cp -r ./testing/manifests/initial/*.crd.yaml{-merge-patch,-patch} ./manifests/
 ! diff -Naup ./testing/manifests/initial/ ./manifests/ 2>/dev/null 1>&2
 diff -Naup ./testing/manifests/updated/ ./manifests/
 make clean
@@ -171,6 +191,8 @@ if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
 rm -f '_output/tools/bin/controller-gen'
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f '_output/tools/bin/yq'
+if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
+rm -f '_output/tools/bin/yaml-patch'
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
@@ -182,6 +204,8 @@ if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
 rm -f '_output/tools/bin/controller-gen'
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f '_output/tools/bin/yq'
+if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
+rm -f '_output/tools/bin/yaml-patch'
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi

--- a/make/examples/multiple-binaries/Makefile.test.log
+++ b/make/examples/multiple-binaries/Makefile.test.log
@@ -115,7 +115,7 @@ diff -Naup ./testing/manifests/initial/ ./manifests/
 ! make verify-codegen-crds
 Installing controller-gen into '_output/tools/bin/controller-gen'
 mkdir -p '_output/tools/bin/'
-curl -s -f -L https://github.com/openshift/kubernetes-sigs-controller-tools/releases/download/v0.2.1-37-ga3cca5d/controller-gen-linux-amd64 -o '_output/tools/bin/controller-gen'
+curl -s -f -L https://github.com/openshift/kubernetes-sigs-controller-tools/releases/download/v0.2.5/controller-gen-linux-amd64 -o '_output/tools/bin/controller-gen'
 chmod +x '_output/tools/bin/controller-gen';
 Installing yq into '_output/tools/bin/yq'
 mkdir -p '_output/tools/bin/'

--- a/make/examples/multiple-binaries/manifests/operator.openshift.io_myv1resources.crd.yaml
+++ b/make/examples/multiple-binaries/manifests/operator.openshift.io_myv1resources.crd.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: myv1resources.operator.openshift.io
+spec:
+  group: operator.openshift.io
+  names:
+    kind: MyV1Resource
+    plural: myv1resources
+  scope: ""
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: MyV1Resource is an example operator configuration type
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - a
+                - b
+                type: string
+            type: object
+          spec:
+            properties:
+              name:
+                type: string
+            required:
+            - name
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/make/examples/multiple-binaries/manifests/operator.openshift.io_myv1resources.crd.yaml-patch
+++ b/make/examples/multiple-binaries/manifests/operator.openshift.io_myv1resources.crd.yaml-patch
@@ -1,0 +1,8 @@
+- op: add
+  path: /spec/versions/name=v1/schema/openAPIV3Schema/properties/metadata/properties
+  value:
+    name:
+      type: string
+      enum:
+      - a
+      - b

--- a/make/examples/multiple-binaries/pkg/apis/v1/register.go
+++ b/make/examples/multiple-binaries/pkg/apis/v1/register.go
@@ -33,6 +33,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 
 	scheme.AddKnownTypes(GroupVersion,
 		&MyOperatorResource{},
+		&MyV1Resource{},
 	)
 
 	return nil

--- a/make/examples/multiple-binaries/pkg/apis/v1/types.go
+++ b/make/examples/multiple-binaries/pkg/apis/v1/types.go
@@ -23,3 +23,23 @@ type MyOperatorResource struct {
 type MyOperatorResourceSpec struct {
 	Name string `json:"name"`
 }
+
+// +genclient
+// +genclient:nonNamespaced
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
+// +kubebuilder:storageversion
+
+// MyV1Resource is an example operator configuration type
+type MyV1Resource struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata"`
+
+	// +kubebuilder:validation:Required
+	// +required
+	Spec MyV1ResourceSpec `json:"spec"`
+}
+
+type MyV1ResourceSpec struct {
+	Name string `json:"name"`
+}

--- a/make/examples/multiple-binaries/testing/manifests/initial/operator.openshift.io_myv1resources.crd.yaml
+++ b/make/examples/multiple-binaries/testing/manifests/initial/operator.openshift.io_myv1resources.crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: myv1resources.operator.openshift.io
+spec:
+  group: operator.openshift.io
+  names:
+    kind: MyV1Resource
+    plural: myv1resources
+  scope: ""
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            pattern: ^(test|TEST)$
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/make/examples/multiple-binaries/testing/manifests/initial/operator.openshift.io_myv1resources.crd.yaml-patch
+++ b/make/examples/multiple-binaries/testing/manifests/initial/operator.openshift.io_myv1resources.crd.yaml-patch
@@ -1,0 +1,8 @@
+- op: add
+  path: /spec/versions/name=v1/schema/openAPIV3Schema/properties/metadata/properties
+  value:
+    name:
+      type: string
+      enum:
+      - a
+      - b

--- a/make/examples/multiple-binaries/testing/manifests/updated/operator.openshift.io_myv1resources.crd.yaml
+++ b/make/examples/multiple-binaries/testing/manifests/updated/operator.openshift.io_myv1resources.crd.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: myv1resources.operator.openshift.io
+spec:
+  group: operator.openshift.io
+  names:
+    kind: MyV1Resource
+    plural: myv1resources
+  scope: ""
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: MyV1Resource is an example operator configuration type
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - a
+                - b
+                type: string
+            type: object
+          spec:
+            properties:
+              name:
+                type: string
+            required:
+            - name
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/make/examples/multiple-binaries/testing/manifests/updated/operator.openshift.io_myv1resources.crd.yaml-patch
+++ b/make/examples/multiple-binaries/testing/manifests/updated/operator.openshift.io_myv1resources.crd.yaml-patch
@@ -1,0 +1,8 @@
+- op: add
+  path: /spec/versions/name=v1/schema/openAPIV3Schema/properties/metadata/properties
+  value:
+    name:
+      type: string
+      enum:
+      - a
+      - b

--- a/make/targets/openshift/controller-gen.mk
+++ b/make/targets/openshift/controller-gen.mk
@@ -1,6 +1,6 @@
 self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
 
-CONTROLLER_GEN_VERSION ?=v0.2.1-37-ga3cca5d
+CONTROLLER_GEN_VERSION ?=v0.2.5
 CONTROLLER_GEN ?=$(PERMANENT_TMP_GOPATH)/bin/controller-gen
 controller_gen_dir :=$(dir $(CONTROLLER_GEN))
 

--- a/make/targets/openshift/yaml-patch.mk
+++ b/make/targets/openshift/yaml-patch.mk
@@ -1,0 +1,32 @@
+self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+
+YAML_PATCH ?=$(PERMANENT_TMP_GOPATH)/bin/yaml-patch
+yaml_patch_dir :=$(dir $(YAML_PATCH))
+
+
+ensure-yaml-patch:
+ifeq "" "$(wildcard $(YAML_PATCH))"
+	$(info Installing yaml-patch into '$(YAML_PATCH)')
+	mkdir -p '$(yaml_patch_dir)'
+	curl -s -f -L https://github.com/krishicks/yaml-patch/releases/download/v0.0.10/yaml_patch_$(GOHOSTOS) -o '$(YAML_PATCH)'
+	chmod +x '$(YAML_PATCH)';
+else
+	$(info Using existing yaml-patch from "$(YAML_PATCH)")
+endif
+.PHONY: ensure-yaml-patch
+
+clean-yaml-patch:
+	$(RM) '$(YAML_PATCH)'
+	if [ -d '$(yaml_patch_dir)' ]; then rmdir --ignore-fail-on-non-empty -p '$(yaml_patch_dir)'; fi
+.PHONY: clean-yaml-patch
+
+clean: clean-yaml-patch
+
+
+# We need to be careful to expand all the paths before any include is done
+# or self_dir could be modified for the next include by the included file.
+# Also doing this at the end of the file allows us to use self_dir before it could be modified.
+include $(addprefix $(self_dir), \
+	../../lib/golang.mk \
+	../../lib/tmp.mk \
+)


### PR DESCRIPTION
YAML merge patches cannot patch discriminated lists like CRDs' versions in v1. Hence, we need a more powerful patch format that can. https://github.com/krishicks/yaml-patch is the tool, following the semantics of json-patch.

Proof PR https://github.com/openshift/api/pull/720.