### PR TITLE
Add scripts to generate/verify profile manifests

### DIFF
--- a/make/examples/multiple-binaries/Makefile
+++ b/make/examples/multiple-binaries/Makefile
@@ -3,6 +3,7 @@ include $(addprefix ../../, \
 	targets/openshift/rpm.mk \
 	targets/openshift/crd-schema-gen.mk \
 	targets/openshift/deps.mk \
+	targets/openshift/operator/profile-manifests.mk \
 )
 
 # Set crd-schema-gen variables
@@ -20,6 +21,17 @@ RPM_EXTRAFLAGS :=--quiet --define 'version 2.42.0' --define 'dist .el7' --define
 # $3 - manifests
 # $4 - output
 $(call add-crd-gen,manifests,$(CRD_APIS),./manifests,./manifests)
+
+# $1 - target name
+# $2 - profile patches dir
+# $3 - manifests dir
+$(call add-profile-manifests,manifests-1,./profile-patches-1,./profile-manifests-1)
+
+# $1 - target name
+# $2 - profile patches dir
+# $3 - manifests dir
+$(call add-profile-manifests,manifests-2,./profile-patches-2,./profile-manifests-2)
+
 
 cross-build-darwin-amd64:
 	+@GOOS=darwin GOARCH=amd64 $(MAKE) --no-print-directory build GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/darwin_amd64

--- a/make/examples/multiple-binaries/Makefile.test
+++ b/make/examples/multiple-binaries/Makefile.test
@@ -1,6 +1,6 @@
 SHELL :=/bin/bash -euo pipefail
 
-test: | test-build test-cross-build test-rpm test-codegen
+test: | test-build test-cross-build test-rpm test-codegen test-profile-manifests
 .PHONY: test
 
 test-build:
@@ -67,3 +67,19 @@ test-codegen:
 	[[ ! -d ./_output/ ]] || (ls -l ./_output/ && false)
 	$(MAKE) clean
 .PHONY: test-codegen
+
+test-profile-manifests:
+	rm -f ./profile-manifests-1/* ./profile-manifests-2/*
+	cp ./testing/profile-manifests/initial/* ./profile-manifests-1/
+	cp ./testing/profile-manifests/initial/* ./profile-manifests-2/
+	! $(MAKE) verify-profile-manifests
+
+	$(MAKE) update-profile-manifests
+	! diff -Naup ./testing/profile-manifests/initial/ ./profile-manifests-1/ &> /dev/null
+	! diff -Naup ./testing/profile-manifests/initial/ ./profile-manifests-2/ &> /dev/null
+	diff -Naup ./testing/profile-manifests/updated-1 ./profile-manifests-1/
+
+	$(MAKE) clean
+	[[ ! -d ./_output/ ]] || (ls -l ./_output/ && false)
+	$(MAKE) clean
+.PHONY: test-profile-manifests

--- a/make/examples/multiple-binaries/Makefile.test.log
+++ b/make/examples/multiple-binaries/Makefile.test.log
@@ -209,3 +209,187 @@ rm -f '_output/tools/bin/yaml-patch'
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
+rm -f ./profile-manifests-1/* ./profile-manifests-2/*
+cp ./testing/profile-manifests/initial/* ./profile-manifests-1/
+cp ./testing/profile-manifests/initial/* ./profile-manifests-2/
+! make verify-profile-manifests
+Installing yq into '_output/tools/bin/yq'
+mkdir -p '_output/tools/bin/'
+curl -s -f -L https://github.com/mikefarah/yq/releases/download/2.4.0/yq_linux_amd64 -o '_output/tools/bin/yq'
+chmod +x '_output/tools/bin/yq';
+Installing yaml-patch into '_output/tools/bin/yaml-patch'
+mkdir -p '_output/tools/bin/'
+curl -s -f -L https://github.com/krishicks/yaml-patch/releases/download/v0.0.10/yaml_patch_linux -o '_output/tools/bin/yaml-patch'
+chmod +x '_output/tools/bin/yaml-patch';
+--- ./profile-manifests-1/operator.deployment-profile1.yaml	1970-01-01 00:00:00.000000000 +0000
+@@ -0,0 +1,44 @@
++apiVersion: apps/v1
++kind: Deployment
++metadata:
++  annotations:
++    cluster-profile: profile1
++  labels:
++    app: my-operator
++  name: my-operator
++  namespace: my-operator
++spec:
++  replicas: 1
++  selector:
++    matchLabels:
++      app: my-operator
++  template:
++    metadata:
++      labels:
++        app: my-operator
++    spec:
++      containers:
++      - args:
++        - --logtostderr
++        - start
++        env:
++        - name: RELEASE_VERSION
++          value: 0.0.1-snapshot
++        image: quay.io/openshift/my-operator:latest
++        name: operator
++        ports:
++        - containerPort: 8443
++          name: https
++        resources:
++          requests:
++            cpu: 100m
++            memory: 1Gi
++        volumeMounts:
++        - mountPath: /config
++          name: config
++      priorityClassName: system-cluster-critical
++      serviceAccountName: operator
++      volumes:
++      - configMap:
++          name: operator-config
++        name: config
+--- ./profile-manifests-1/operator.deployment-profile2.yaml	1970-01-01 00:00:00.000000000 +0000
+@@ -0,0 +1,46 @@
++apiVersion: apps/v1
++kind: Deployment
++metadata:
++  annotations:
++    cluster-profile: profile2
++  labels:
++    app: my-operator
++  name: my-operator
++  namespace: my-operator
++spec:
++  replicas: 1
++  selector:
++    matchLabels:
++      app: my-operator
++  template:
++    metadata:
++      labels:
++        app: my-operator
++    spec:
++      containers:
++      - args:
++        - --logtostderr
++        - start
++        env:
++        - name: RELEASE_VERSION
++          value: 0.0.1-snapshot
++        image: quay.io/openshift/my-operator:latest
++        name: operator
++        ports:
++        - containerPort: 8443
++          name: https
++        resources:
++          requests:
++            cpu: 100m
++            memory: 1Gi
++        volumeMounts:
++        - mountPath: /config
++          name: config
++      nodeSelector:
++        node-role.kubernetes.io/master: ""
++      priorityClassName: system-cluster-critical
++      serviceAccountName: operator
++      volumes:
++      - configMap:
++          name: operator-config
++        name: config
+--- ./profile-manifests-1/operator.service-profile1.yaml	1970-01-01 00:00:00.000000000 +0000
+@@ -0,0 +1,17 @@
++apiVersion: v1
++kind: Service
++metadata:
++  annotations:
++    include.release.openshift.io/self-managed-high-availability: "true"
++  labels:
++    app: my-operator
++    cluster-profile: profile1
++  name: my-operator
++  namespace: my-operator
++spec:
++  ports:
++  - name: https
++    port: 8443
++  selector:
++    app: my-operator
++  type: ClusterIP
+--- ./profile-manifests-1/operator.service-profile2.yaml	1970-01-01 00:00:00.000000000 +0000
+@@ -0,0 +1,17 @@
++apiVersion: v1
++kind: Service
++metadata:
++  annotations:
++    include.release.openshift.io/self-managed-high-availability: "true"
++  labels:
++    app: my-operator
++    cluster-profile: profile2
++  name: my-operator
++  namespace: my-operator
++spec:
++  ports:
++  - name: https
++    port: 8443
++  selector:
++    app: my-operator
++  type: ClusterIP
+make[2]: *** [verify-profile-manifests-manifests-1] Error 1
+make update-profile-manifests
+Using existing yq from "_output/tools/bin/yq"
+Using existing yaml-patch from "_output/tools/bin/yaml-patch"
+_output/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/profile-manifests-1/operator.deployment-profile1.yaml'
+_output/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/profile-manifests-1/operator.deployment-profile2.yaml'
+_output/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/profile-manifests-1/operator.service-profile1.yaml'
+_output/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/profile-manifests-1/operator.service-profile2.yaml'
+_output/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/profile-manifests-2/operator.deployment-profile-a.yaml'
+_output/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/profile-manifests-2/operator.deployment-profile-b.yaml'
+_output/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/profile-manifests-2/operator.service-profile-a.yaml'
+_output/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/profile-manifests-2/operator.service-profile-b.yaml'
+! diff -Naup ./testing/profile-manifests/initial/ ./profile-manifests-1/ &> /dev/null
+! diff -Naup ./testing/profile-manifests/initial/ ./profile-manifests-2/ &> /dev/null
+diff -Naup ./testing/profile-manifests/updated-1 ./profile-manifests-1/
+make clean
+rm -f oc openshift
+rm -f -r '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/srpms'
+if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
+rm -f '_output/tools/bin/controller-gen'
+if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
+rm -f '_output/tools/bin/yq'
+if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
+rm -f '_output/tools/bin/yaml-patch'
+if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
+rm -f -r '_output/bin'
+if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
+[[ ! -d ./_output/ ]] || (ls -l ./_output/ && false)
+make clean
+rm -f oc openshift
+rm -f -r '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/srpms'
+if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
+rm -f '_output/tools/bin/controller-gen'
+if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
+rm -f '_output/tools/bin/yq'
+if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
+rm -f '_output/tools/bin/yaml-patch'
+if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
+rm -f -r '_output/bin'
+if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi

--- a/make/examples/multiple-binaries/profile-manifests-1/operator.deployment-profile1.yaml
+++ b/make/examples/multiple-binaries/profile-manifests-1/operator.deployment-profile1.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    cluster-profile: profile1
+  labels:
+    app: my-operator
+  name: my-operator
+  namespace: my-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-operator
+  template:
+    metadata:
+      labels:
+        app: my-operator
+    spec:
+      containers:
+      - args:
+        - --logtostderr
+        - start
+        env:
+        - name: RELEASE_VERSION
+          value: 0.0.1-snapshot
+        image: quay.io/openshift/my-operator:latest
+        name: operator
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /config
+          name: config
+      priorityClassName: system-cluster-critical
+      serviceAccountName: operator
+      volumes:
+      - configMap:
+          name: operator-config
+        name: config

--- a/make/examples/multiple-binaries/profile-manifests-1/operator.deployment-profile2.yaml
+++ b/make/examples/multiple-binaries/profile-manifests-1/operator.deployment-profile2.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    cluster-profile: profile2
+  labels:
+    app: my-operator
+  name: my-operator
+  namespace: my-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-operator
+  template:
+    metadata:
+      labels:
+        app: my-operator
+    spec:
+      containers:
+      - args:
+        - --logtostderr
+        - start
+        env:
+        - name: RELEASE_VERSION
+          value: 0.0.1-snapshot
+        image: quay.io/openshift/my-operator:latest
+        name: operator
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /config
+          name: config
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: system-cluster-critical
+      serviceAccountName: operator
+      volumes:
+      - configMap:
+          name: operator-config
+        name: config

--- a/make/examples/multiple-binaries/profile-manifests-1/operator.deployment.yaml
+++ b/make/examples/multiple-binaries/profile-manifests-1/operator.deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-operator
+  namespace: my-operator
+  labels:
+    app: my-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-operator
+  template:
+    metadata:
+      labels:
+        app: my-operator
+    spec:
+      serviceAccountName: operator
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
+      volumes:
+      - name: config
+        configMap:
+          name: operator-config
+      containers:
+      - args:
+        - --logtostderr
+        - start
+        image: quay.io/openshift/my-operator:latest
+        name: operator
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /config
+          name: config
+        env:
+        - name: RELEASE_VERSION
+          value: "0.0.1-snapshot"

--- a/make/examples/multiple-binaries/profile-manifests-1/operator.namespace.yaml
+++ b/make/examples/multiple-binaries/profile-manifests-1/operator.namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    name: my-operator

--- a/make/examples/multiple-binaries/profile-manifests-1/operator.service-profile1.yaml
+++ b/make/examples/multiple-binaries/profile-manifests-1/operator.service-profile1.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    app: my-operator
+    cluster-profile: profile1
+  name: my-operator
+  namespace: my-operator
+spec:
+  ports:
+  - name: https
+    port: 8443
+  selector:
+    app: my-operator
+  type: ClusterIP

--- a/make/examples/multiple-binaries/profile-manifests-1/operator.service-profile2.yaml
+++ b/make/examples/multiple-binaries/profile-manifests-1/operator.service-profile2.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    app: my-operator
+    cluster-profile: profile2
+  name: my-operator
+  namespace: my-operator
+spec:
+  ports:
+  - name: https
+    port: 8443
+  selector:
+    app: my-operator
+  type: ClusterIP

--- a/make/examples/multiple-binaries/profile-manifests-1/operator.service.yaml
+++ b/make/examples/multiple-binaries/profile-manifests-1/operator.service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-operator
+  namespace: my-operator
+  labels:
+    app: my-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  type: ClusterIP
+  selector:
+    app: my-operator
+  ports:
+  - name: https
+    port: 8443

--- a/make/examples/multiple-binaries/profile-manifests-2/operator.deployment-profile-a.yaml
+++ b/make/examples/multiple-binaries/profile-manifests-2/operator.deployment-profile-a.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    cluster-profile: profile-a
+  labels:
+    app: my-operator
+  name: my-operator
+  namespace: my-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-operator
+  template:
+    metadata:
+      labels:
+        app: my-operator
+    spec:
+      containers:
+      - args:
+        - --logtostderr
+        - start
+        env:
+        - name: RELEASE_VERSION
+          value: 0.0.1-snapshot
+        image: quay.io/openshift/my-operator:latest
+        name: operator
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /config
+          name: config
+      priorityClassName: system-cluster-critical
+      serviceAccountName: operator
+      volumes:
+      - configMap:
+          name: operator-config
+        name: config

--- a/make/examples/multiple-binaries/profile-manifests-2/operator.deployment-profile-b.yaml
+++ b/make/examples/multiple-binaries/profile-manifests-2/operator.deployment-profile-b.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    cluster-profile: profile-b
+  labels:
+    app: my-operator
+  name: my-operator
+  namespace: my-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-operator
+  template:
+    metadata:
+      labels:
+        app: my-operator
+    spec:
+      containers:
+      - args:
+        - --logtostderr
+        - start
+        env:
+        - name: RELEASE_VERSION
+          value: 0.0.1-snapshot
+        image: quay.io/openshift/my-operator:latest
+        name: operator
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /config
+          name: config
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: system-cluster-critical
+      serviceAccountName: operator
+      volumes:
+      - configMap:
+          name: operator-config
+        name: config

--- a/make/examples/multiple-binaries/profile-manifests-2/operator.deployment.yaml
+++ b/make/examples/multiple-binaries/profile-manifests-2/operator.deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-operator
+  namespace: my-operator
+  labels:
+    app: my-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-operator
+  template:
+    metadata:
+      labels:
+        app: my-operator
+    spec:
+      serviceAccountName: operator
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
+      volumes:
+      - name: config
+        configMap:
+          name: operator-config
+      containers:
+      - args:
+        - --logtostderr
+        - start
+        image: quay.io/openshift/my-operator:latest
+        name: operator
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /config
+          name: config
+        env:
+        - name: RELEASE_VERSION
+          value: "0.0.1-snapshot"

--- a/make/examples/multiple-binaries/profile-manifests-2/operator.namespace.yaml
+++ b/make/examples/multiple-binaries/profile-manifests-2/operator.namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    name: my-operator

--- a/make/examples/multiple-binaries/profile-manifests-2/operator.service-profile-a.yaml
+++ b/make/examples/multiple-binaries/profile-manifests-2/operator.service-profile-a.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    app: my-operator
+    cluster-profile: profile-a
+  name: my-operator
+  namespace: my-operator
+spec:
+  ports:
+  - name: https
+    port: 8443
+  selector:
+    app: my-operator
+  type: ClusterIP

--- a/make/examples/multiple-binaries/profile-manifests-2/operator.service-profile-b.yaml
+++ b/make/examples/multiple-binaries/profile-manifests-2/operator.service-profile-b.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    app: my-operator
+    cluster-profile: profile-b
+  name: my-operator
+  namespace: my-operator
+spec:
+  ports:
+  - name: https
+    port: 8443
+  selector:
+    app: my-operator
+  type: ClusterIP

--- a/make/examples/multiple-binaries/profile-manifests-2/operator.service.yaml
+++ b/make/examples/multiple-binaries/profile-manifests-2/operator.service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-operator
+  namespace: my-operator
+  labels:
+    app: my-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  type: ClusterIP
+  selector:
+    app: my-operator
+  ports:
+  - name: https
+    port: 8443

--- a/make/examples/multiple-binaries/profile-patches-1/profile1/operator.deployment.yaml-patch
+++ b/make/examples/multiple-binaries/profile-patches-1/profile1/operator.deployment.yaml-patch
@@ -1,0 +1,8 @@
+- op: remove
+  path: /metadata/annotations
+- op: add
+  path: /metadata/annotations
+  value:
+    cluster-profile: profile1
+- op: remove
+  path: /spec/template/spec/nodeSelector

--- a/make/examples/multiple-binaries/profile-patches-1/profile1/operator.service.yaml-merge-patch
+++ b/make/examples/multiple-binaries/profile-patches-1/profile1/operator.service.yaml-merge-patch
@@ -1,0 +1,3 @@
+metadata:
+  labels:
+    cluster-profile: profile1

--- a/make/examples/multiple-binaries/profile-patches-1/profile2/operator.deployment.yaml-patch
+++ b/make/examples/multiple-binaries/profile-patches-1/profile2/operator.deployment.yaml-patch
@@ -1,0 +1,6 @@
+- op: remove
+  path: /metadata/annotations
+- op: add
+  path: /metadata/annotations
+  value:
+    cluster-profile: profile2

--- a/make/examples/multiple-binaries/profile-patches-1/profile2/operator.service.yaml-merge-patch
+++ b/make/examples/multiple-binaries/profile-patches-1/profile2/operator.service.yaml-merge-patch
@@ -1,0 +1,3 @@
+metadata:
+  labels:
+    cluster-profile: profile2

--- a/make/examples/multiple-binaries/profile-patches-2/profile-a/operator.deployment.yaml-patch
+++ b/make/examples/multiple-binaries/profile-patches-2/profile-a/operator.deployment.yaml-patch
@@ -1,0 +1,8 @@
+- op: remove
+  path: /metadata/annotations
+- op: add
+  path: /metadata/annotations
+  value:
+    cluster-profile: profile-a
+- op: remove
+  path: /spec/template/spec/nodeSelector

--- a/make/examples/multiple-binaries/profile-patches-2/profile-a/operator.service.yaml-merge-patch
+++ b/make/examples/multiple-binaries/profile-patches-2/profile-a/operator.service.yaml-merge-patch
@@ -1,0 +1,3 @@
+metadata:
+  labels:
+    cluster-profile: profile-a

--- a/make/examples/multiple-binaries/profile-patches-2/profile-b/operator.deployment.yaml-patch
+++ b/make/examples/multiple-binaries/profile-patches-2/profile-b/operator.deployment.yaml-patch
@@ -1,0 +1,6 @@
+- op: remove
+  path: /metadata/annotations
+- op: add
+  path: /metadata/annotations
+  value:
+    cluster-profile: profile-b

--- a/make/examples/multiple-binaries/profile-patches-2/profile-b/operator.service.yaml-merge-patch
+++ b/make/examples/multiple-binaries/profile-patches-2/profile-b/operator.service.yaml-merge-patch
@@ -1,0 +1,3 @@
+metadata:
+  labels:
+    cluster-profile: profile-b

--- a/make/examples/multiple-binaries/testing/profile-manifests/initial/operator.deployment.yaml
+++ b/make/examples/multiple-binaries/testing/profile-manifests/initial/operator.deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-operator
+  namespace: my-operator
+  labels:
+    app: my-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-operator
+  template:
+    metadata:
+      labels:
+        app: my-operator
+    spec:
+      serviceAccountName: operator
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
+      volumes:
+      - name: config
+        configMap:
+          name: operator-config
+      containers:
+      - args:
+        - --logtostderr
+        - start
+        image: quay.io/openshift/my-operator:latest
+        name: operator
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /config
+          name: config
+        env:
+        - name: RELEASE_VERSION
+          value: "0.0.1-snapshot"

--- a/make/examples/multiple-binaries/testing/profile-manifests/initial/operator.namespace.yaml
+++ b/make/examples/multiple-binaries/testing/profile-manifests/initial/operator.namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    name: my-operator

--- a/make/examples/multiple-binaries/testing/profile-manifests/initial/operator.service.yaml
+++ b/make/examples/multiple-binaries/testing/profile-manifests/initial/operator.service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-operator
+  namespace: my-operator
+  labels:
+    app: my-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  type: ClusterIP
+  selector:
+    app: my-operator
+  ports:
+  - name: https
+    port: 8443

--- a/make/examples/multiple-binaries/testing/profile-manifests/updated-1/operator.deployment-profile1.yaml
+++ b/make/examples/multiple-binaries/testing/profile-manifests/updated-1/operator.deployment-profile1.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    cluster-profile: profile1
+  labels:
+    app: my-operator
+  name: my-operator
+  namespace: my-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-operator
+  template:
+    metadata:
+      labels:
+        app: my-operator
+    spec:
+      containers:
+      - args:
+        - --logtostderr
+        - start
+        env:
+        - name: RELEASE_VERSION
+          value: 0.0.1-snapshot
+        image: quay.io/openshift/my-operator:latest
+        name: operator
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /config
+          name: config
+      priorityClassName: system-cluster-critical
+      serviceAccountName: operator
+      volumes:
+      - configMap:
+          name: operator-config
+        name: config

--- a/make/examples/multiple-binaries/testing/profile-manifests/updated-1/operator.deployment-profile2.yaml
+++ b/make/examples/multiple-binaries/testing/profile-manifests/updated-1/operator.deployment-profile2.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    cluster-profile: profile2
+  labels:
+    app: my-operator
+  name: my-operator
+  namespace: my-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-operator
+  template:
+    metadata:
+      labels:
+        app: my-operator
+    spec:
+      containers:
+      - args:
+        - --logtostderr
+        - start
+        env:
+        - name: RELEASE_VERSION
+          value: 0.0.1-snapshot
+        image: quay.io/openshift/my-operator:latest
+        name: operator
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /config
+          name: config
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: system-cluster-critical
+      serviceAccountName: operator
+      volumes:
+      - configMap:
+          name: operator-config
+        name: config

--- a/make/examples/multiple-binaries/testing/profile-manifests/updated-1/operator.deployment.yaml
+++ b/make/examples/multiple-binaries/testing/profile-manifests/updated-1/operator.deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-operator
+  namespace: my-operator
+  labels:
+    app: my-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-operator
+  template:
+    metadata:
+      labels:
+        app: my-operator
+    spec:
+      serviceAccountName: operator
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
+      volumes:
+      - name: config
+        configMap:
+          name: operator-config
+      containers:
+      - args:
+        - --logtostderr
+        - start
+        image: quay.io/openshift/my-operator:latest
+        name: operator
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /config
+          name: config
+        env:
+        - name: RELEASE_VERSION
+          value: "0.0.1-snapshot"

--- a/make/examples/multiple-binaries/testing/profile-manifests/updated-1/operator.namespace.yaml
+++ b/make/examples/multiple-binaries/testing/profile-manifests/updated-1/operator.namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    name: my-operator

--- a/make/examples/multiple-binaries/testing/profile-manifests/updated-1/operator.service-profile1.yaml
+++ b/make/examples/multiple-binaries/testing/profile-manifests/updated-1/operator.service-profile1.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    app: my-operator
+    cluster-profile: profile1
+  name: my-operator
+  namespace: my-operator
+spec:
+  ports:
+  - name: https
+    port: 8443
+  selector:
+    app: my-operator
+  type: ClusterIP

--- a/make/examples/multiple-binaries/testing/profile-manifests/updated-1/operator.service-profile2.yaml
+++ b/make/examples/multiple-binaries/testing/profile-manifests/updated-1/operator.service-profile2.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    app: my-operator
+    cluster-profile: profile2
+  name: my-operator
+  namespace: my-operator
+spec:
+  ports:
+  - name: https
+    port: 8443
+  selector:
+    app: my-operator
+  type: ClusterIP

--- a/make/examples/multiple-binaries/testing/profile-manifests/updated-1/operator.service.yaml
+++ b/make/examples/multiple-binaries/testing/profile-manifests/updated-1/operator.service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-operator
+  namespace: my-operator
+  labels:
+    app: my-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  type: ClusterIP
+  selector:
+    app: my-operator
+  ports:
+  - name: https
+    port: 8443

--- a/make/examples/multiple-binaries/testing/profile-manifests/updated-2/operator.deployment-profile-a.yaml
+++ b/make/examples/multiple-binaries/testing/profile-manifests/updated-2/operator.deployment-profile-a.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    cluster-profile: profile-a
+  labels:
+    app: my-operator
+  name: my-operator
+  namespace: my-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-operator
+  template:
+    metadata:
+      labels:
+        app: my-operator
+    spec:
+      containers:
+      - args:
+        - --logtostderr
+        - start
+        env:
+        - name: RELEASE_VERSION
+          value: 0.0.1-snapshot
+        image: quay.io/openshift/my-operator:latest
+        name: operator
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /config
+          name: config
+      priorityClassName: system-cluster-critical
+      serviceAccountName: operator
+      volumes:
+      - configMap:
+          name: operator-config
+        name: config

--- a/make/examples/multiple-binaries/testing/profile-manifests/updated-2/operator.deployment-profile-b.yaml
+++ b/make/examples/multiple-binaries/testing/profile-manifests/updated-2/operator.deployment-profile-b.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    cluster-profile: profile-b
+  labels:
+    app: my-operator
+  name: my-operator
+  namespace: my-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-operator
+  template:
+    metadata:
+      labels:
+        app: my-operator
+    spec:
+      containers:
+      - args:
+        - --logtostderr
+        - start
+        env:
+        - name: RELEASE_VERSION
+          value: 0.0.1-snapshot
+        image: quay.io/openshift/my-operator:latest
+        name: operator
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /config
+          name: config
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: system-cluster-critical
+      serviceAccountName: operator
+      volumes:
+      - configMap:
+          name: operator-config
+        name: config

--- a/make/examples/multiple-binaries/testing/profile-manifests/updated-2/operator.deployment.yaml
+++ b/make/examples/multiple-binaries/testing/profile-manifests/updated-2/operator.deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-operator
+  namespace: my-operator
+  labels:
+    app: my-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-operator
+  template:
+    metadata:
+      labels:
+        app: my-operator
+    spec:
+      serviceAccountName: operator
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
+      volumes:
+      - name: config
+        configMap:
+          name: operator-config
+      containers:
+      - args:
+        - --logtostderr
+        - start
+        image: quay.io/openshift/my-operator:latest
+        name: operator
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /config
+          name: config
+        env:
+        - name: RELEASE_VERSION
+          value: "0.0.1-snapshot"

--- a/make/examples/multiple-binaries/testing/profile-manifests/updated-2/operator.namespace.yaml
+++ b/make/examples/multiple-binaries/testing/profile-manifests/updated-2/operator.namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    name: my-operator

--- a/make/examples/multiple-binaries/testing/profile-manifests/updated-2/operator.service-profile-a.yaml
+++ b/make/examples/multiple-binaries/testing/profile-manifests/updated-2/operator.service-profile-a.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    app: my-operator
+    cluster-profile: profile-a
+  name: my-operator
+  namespace: my-operator
+spec:
+  ports:
+  - name: https
+    port: 8443
+  selector:
+    app: my-operator
+  type: ClusterIP

--- a/make/examples/multiple-binaries/testing/profile-manifests/updated-2/operator.service-profile-b.yaml
+++ b/make/examples/multiple-binaries/testing/profile-manifests/updated-2/operator.service-profile-b.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    app: my-operator
+    cluster-profile: profile-b
+  name: my-operator
+  namespace: my-operator
+spec:
+  ports:
+  - name: https
+    port: 8443
+  selector:
+    app: my-operator
+  type: ClusterIP

--- a/make/examples/multiple-binaries/testing/profile-manifests/updated-2/operator.service.yaml
+++ b/make/examples/multiple-binaries/testing/profile-manifests/updated-2/operator.service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-operator
+  namespace: my-operator
+  labels:
+    app: my-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  type: ClusterIP
+  selector:
+    app: my-operator
+  ports:
+  - name: https
+    port: 8443

--- a/make/operator.example.mk.help.log
+++ b/make/operator.example.mk.help.log
@@ -3,6 +3,10 @@ all
 build
 clean
 clean-binaries
+clean-yaml-patch
+clean-yq
+ensure-yaml-patch
+ensure-yq
 help
 image-ocp-openshift-apiserver-operator
 images
@@ -15,6 +19,7 @@ update-codegen
 update-deps-overrides
 update-generated
 update-gofmt
+update-profile-manifests
 verify
 verify-bindata
 verify-codegen
@@ -23,3 +28,4 @@ verify-generated
 verify-gofmt
 verify-golint
 verify-govet
+verify-profile-manifests

--- a/make/targets/openshift/operator/profile-manifests.mk
+++ b/make/targets/openshift/operator/profile-manifests.mk
@@ -1,0 +1,97 @@
+self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+
+# Merge yaml patch using mikefarah/yq
+# $1 - patch file
+# $2 - manifest file
+# $3 - output file
+define patch-manifest-yq
+	$(YQ) m -x '$(2)' '$(1)' > '$(3)'
+	
+endef
+
+# Apply yaml-patch using krishicks/yaml-patch
+# $1 - patch file
+# $2 - manifest file
+# $3 - output file
+define patch-manifest-yaml-patch
+	$(YAML_PATCH) -o '$(1)' < '$(2)' > '$(3)'
+
+endef
+
+# List of patches of type 'yaml-patch'
+# $1 - patch dir
+define profile-yaml-patches
+	$(shell find $(1) -type f -name '*.yaml-patch')
+endef
+
+# List of patches of type 'yaml-merge-patch'
+# $1 - patch dir
+define profile-yaml-merge-patches
+	$(shell find $(1) -type f -name '*.yaml-merge-patch')
+endef
+
+# Apply profile patches to manifests
+# $1 - patch dir
+# $2 - manifests dir
+define apply-profile-manifest-patches
+	$$(foreach p,$$(call profile-yaml-patches,$(1)),$$(call patch-manifest-yaml-patch,$$(p),$$(realpath $(2))/$$(basename $$(notdir $$(p))).yaml,$$(realpath $(2))/$$(basename $$(notdir $$(p)))-$$(notdir $$(realpath $$(dir $$(p)))).yaml))
+	$$(foreach p,$$(call profile-yaml-merge-patches,$(1)),$$(call patch-manifest-yq,$$(p),$$(realpath $(2))/$$(basename $$(notdir $$(p))).yaml,$$(realpath $(2))/$$(basename $$(notdir $$(p)))-$$(notdir $$(realpath $$(dir $$(p)))).yaml))
+endef
+
+# $1 - target name
+# $2 - patch dir
+# $3 - manifest dir
+define add-profile-manifests-internal
+
+update-profile-manifests-$(1): ensure-yq ensure-yaml-patch
+	$(call apply-profile-manifest-patches,$(2),$(3),$(3))
+.PHONY: update-profile-manifests-$(1)
+
+update-profile-manifests: update-profile-manifests-$(1)
+.PHONY: update-profile-manifests
+
+foobar := /var/folders/_0/rfp4rhc541n6xqsmlskjyd300000gn/T/tmp.Rpt8z3Jb
+
+verify-profile-manifests-$(1): VERIFY_PROFILE_MANIFESTS_TMP_DIR:=$$(shell mktemp -d)
+verify-profile-manifests-$(1): ensure-yq ensure-yaml-patch
+	cp $(3)/* $$(VERIFY_PROFILE_MANIFESTS_TMP_DIR)/
+	$(call apply-profile-manifest-patches,$(2),$$(VERIFY_PROFILE_MANIFESTS_TMP_DIR))
+	diff -Naup $(3) $$(VERIFY_PROFILE_MANIFESTS_TMP_DIR)
+.PHONY: verify-profile-manifests-$(1)
+
+verify-profile-manifests: verify-profile-manifests-$(1)
+.PHONY: verify-profile-manifests
+
+update-generated: update-profile-manifests
+.PHONY: update-generated
+
+update: update-generated
+.PHONY: update
+
+verify-generated: verify-profile-manifests
+.PHONY: verify-generated
+
+verify: verify-generated
+.PHONY: verify
+
+endef
+
+
+
+
+# $1 - target name
+# $2 - profile patches dir
+# $3 - manifests dir
+define add-profile-manifests
+$(eval $(call add-profile-manifests-internal,$(1),$(2),$(3)))
+endef
+
+
+# We need to be careful to expand all the paths before any include is done
+# or self_dir could be modified for the next include by the included file.
+# Also doing this at the end of the file allows us to use self_dir before it could be modified.
+include $(addprefix $(self_dir), \
+	../../../lib/tmp.mk \
+	../yq.mk \
+        ../yaml-patch.mk \
+)

--- a/make/targets/openshift/operator/profile-manifests.mk
+++ b/make/targets/openshift/operator/profile-manifests.mk
@@ -6,7 +6,7 @@ self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
 # $3 - output file
 define patch-manifest-yq
 	$(YQ) m -x '$(2)' '$(1)' > '$(3)'
-	
+
 endef
 
 # Apply yaml-patch using krishicks/yaml-patch
@@ -18,17 +18,8 @@ define patch-manifest-yaml-patch
 
 endef
 
-# List of patches of type 'yaml-patch'
-# $1 - patch dir
-define profile-yaml-patches
-	$(shell find $(1) -type f -name '*.yaml-patch')
-endef
-
-# List of patches of type 'yaml-merge-patch'
-# $1 - patch dir
-define profile-yaml-merge-patches
-	$(shell find $(1) -type f -name '*.yaml-merge-patch')
-endef
+profile-yaml-patches = $(sort $(shell find $(1) -type f -name '*.yaml-patch'))
+profile-yaml-merge-patches = $(sort $(shell find $(1) -type f -name '*.yaml-merge-patch'))
 
 # Apply profile patches to manifests
 # $1 - patch dir
@@ -44,17 +35,15 @@ endef
 define add-profile-manifests-internal
 
 update-profile-manifests-$(1): ensure-yq ensure-yaml-patch
-	$(call apply-profile-manifest-patches,$(2),$(3),$(3))
+	$(call apply-profile-manifest-patches,$(2),$(3))
 .PHONY: update-profile-manifests-$(1)
 
 update-profile-manifests: update-profile-manifests-$(1)
 .PHONY: update-profile-manifests
 
-foobar := /var/folders/_0/rfp4rhc541n6xqsmlskjyd300000gn/T/tmp.Rpt8z3Jb
-
 verify-profile-manifests-$(1): VERIFY_PROFILE_MANIFESTS_TMP_DIR:=$$(shell mktemp -d)
 verify-profile-manifests-$(1): ensure-yq ensure-yaml-patch
-	cp $(3)/* $$(VERIFY_PROFILE_MANIFESTS_TMP_DIR)/
+	cp -R $(3)/* $$(VERIFY_PROFILE_MANIFESTS_TMP_DIR)/
 	$(call apply-profile-manifest-patches,$(2),$$(VERIFY_PROFILE_MANIFESTS_TMP_DIR))
 	diff -Naup $(3) $$(VERIFY_PROFILE_MANIFESTS_TMP_DIR)
 .PHONY: verify-profile-manifests-$(1)
@@ -77,8 +66,6 @@ verify: verify-generated
 endef
 
 
-
-
 # $1 - target name
 # $2 - profile patches dir
 # $3 - manifests dir
@@ -93,5 +80,5 @@ endef
 include $(addprefix $(self_dir), \
 	../../../lib/tmp.mk \
 	../yq.mk \
-        ../yaml-patch.mk \
+	../yaml-patch.mk \
 )

--- a/make/targets/openshift/yaml-patch.mk
+++ b/make/targets/openshift/yaml-patch.mk
@@ -1,3 +1,5 @@
+ifndef _YAML_PATCH_MK_
+_YAML_PATCH_MK_ := defined
 self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
 
 YAML_PATCH ?=$(PERMANENT_TMP_GOPATH)/bin/yaml-patch
@@ -30,3 +32,4 @@ include $(addprefix $(self_dir), \
 	../../lib/golang.mk \
 	../../lib/tmp.mk \
 )
+endif

--- a/make/targets/openshift/yq.mk
+++ b/make/targets/openshift/yq.mk
@@ -1,3 +1,5 @@
+ifndef _YQ_MK_
+_YQ_MK_ := defined
 self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
 
 YQ ?=$(PERMANENT_TMP_GOPATH)/bin/yq
@@ -30,3 +32,4 @@ include $(addprefix $(self_dir), \
 	../../lib/golang.mk \
 	../../lib/tmp.mk \
 )
+endif


### PR DESCRIPTION
Adds the following make targets:
- update-profile-manifests:
  Ensures that profile-specific manifests have been generated from
  patches in the profile-patches directory.

- verify-profile-manifests:
  Verifies whether profile-specific manifests are up to date.
