### PR TITLE
golang: Add verify-gomod to test go mod tidy

### DIFF
--- a/make/default.example.mk.help.log
+++ b/make/default.example.mk.help.log
@@ -21,4 +21,5 @@ verify-deps
 verify-generated
 verify-gofmt
 verify-golint
+verify-gomod
 verify-govet

--- a/make/golang.example.mk.help.log
+++ b/make/golang.example.mk.help.log
@@ -11,4 +11,5 @@ update-gofmt
 verify
 verify-gofmt
 verify-golint
+verify-gomod
 verify-govet

--- a/make/operator.example.mk.help.log
+++ b/make/operator.example.mk.help.log
@@ -22,4 +22,5 @@ verify-deps
 verify-generated
 verify-gofmt
 verify-golint
+verify-gomod
 verify-govet

--- a/make/targets/golang/verify-update.mk
+++ b/make/targets/golang/verify-update.mk
@@ -28,6 +28,29 @@ verify-golint:
 	$(GOLINT) $(GO_PACKAGES)
 .PHONY: verify-govet
 
+verify-gomod:
+	$(info Running `$(GO) mod tidy`.)
+	@if ! [ -f go.mod ]; then \
+		echo "$@ failed - please run \`go mod init\`"; \
+		exit 1; \
+	fi; \
+	if ! [ -f go.sum ]; then \
+		echo "$@ failed - please run \`make update-gomod\`"; \
+		exit 1; \
+	fi; \
+	TMP_GOMOD=$$( mktemp ); \
+	TMP_GOSUM=$$( mktemp ); \
+	cp --preserve=all go.mod $${TMP_GOMOD}; \
+	cp --preserve=all go.sum $${TMP_GOSUM}; \
+	$(GO) mod tidy; \
+	if ! { diff $${TMP_GOMOD} go.mod && diff $${TMP_GOSUM} go.sum; }; then \
+		mv $${TMP_GOMOD} go.mod; \
+		mv $${TMP_GOSUM} go.sum; \
+		echo "$@ failed - please run \`$(GO) mod tidy\`"; \
+		exit 1; \
+	fi;
+.PHONY: verify-gomod
+
 # We need to be careful to expand all the paths before any include is done
 # or self_dir could be modified for the next include by the included file.
 # Also doing this at the end of the file allows us to use self_dir before it could be modified.


### PR DESCRIPTION
This patch add a new target: `verify-gomod`

`verify-gomod` exits with 1 if running `go mod tidy` would change
`go.mod` or `go.sum`. The working directory is left as if untouched.

The new target is not hooked into the `verify` target; this is to avoid
breaking existing wofkflows.
