### PR TITLE
bug 1911211: Prefer OS_GIT_VERSION over SOURCE_GIT_TAG when getting build version

### DIFF
--- a/make/lib/golang.mk
+++ b/make/lib/golang.mk
@@ -54,8 +54,14 @@ SOURCE_GIT_TAG ?=$(shell git describe --long --tags --abbrev=7 --match 'v[0-9]*'
 SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)
 SOURCE_GIT_TREE_STATE ?=$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty')
 
+# OS_GIT_VERSION is populated by ART
+# If building out of the ART pipeline, fallback to SOURCE_GIT_TAG
+ifndef OS_GIT_VERSION
+	OS_GIT_VERSION = $(SOURCE_GIT_TAG)
+endif
+
 define version-ldflags
--X $(1).versionFromGit="$(SOURCE_GIT_TAG)" \
+-X $(1).versionFromGit="$(OS_GIT_VERSION)" \
 -X $(1).commitFromGit="$(SOURCE_GIT_COMMIT)" \
 -X $(1).gitTreeState="$(SOURCE_GIT_TREE_STATE)" \
 -X $(1).buildDate="$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')"


### PR DESCRIPTION
When ART builds an image, it copies the content of the source (github) repo into a production repo, and builds from that. The added SOURCE_GIT_* vars in Dockerfile are intended to relay the state of the *original* source repo, in case that is important at build or runtime.

To get the production version, one needs to read OS_GIT_VERSION instead.

Before:
```
go build -mod=vendor -trimpath -ldflags
"-s -w -X
github.com/openshift/cluster-kube-controller-manager-operator/pkg/version.versionFromGit="v0.0.0-alpha.0-897-gd95b645"
-X
github.com/openshift/cluster-kube-controller-manager-operator/pkg/version.commitFromGit="d95b6453"
-X
github.com/openshift/cluster-kube-controller-manager-operator/pkg/version.gitTreeState="dirty"
-X
github.com/openshift/cluster-kube-controller-manager-operator/pkg/version.buildDate="2021-02-03T09:53:46Z"
"
github.com/openshift/cluster-kube-controller-manager-operator/cmd/cluster-kube-controller-manager-operator
```

After:
```
go build -mod=vendor -trimpath -ldflags
"-s -w -X
github.com/openshift/cluster-kube-controller-manager-operator/pkg/version.versionFromGit="4.7.0-202101230053.p0"
-X
github.com/openshift/cluster-kube-controller-manager-operator/pkg/version.commitFromGit="d95b6453"
-X
github.com/openshift/cluster-kube-controller-manager-operator/pkg/version.gitTreeState="dirty"
-X
github.com/openshift/cluster-kube-controller-manager-operator/pkg/version.buildDate="2021-02-03T09:53:57Z"
"
github.com/openshift/cluster-kube-controller-manager-operator/cmd/cluster-kube-controller-manager-operator
```

/hold
Waiting for 4.8 time frame

We should check if this change is sane for any consumer. One might be relying on `SOURCE_GIT_TAG` actually to have the upstream format.