### PR TITLE
ensure imagebuilder

### DIFF
--- a/make/default.example.mk.help.log
+++ b/make/default.example.mk.help.log
@@ -3,6 +3,7 @@ all
 build
 clean
 clean-binaries
+ensure-imagebuilder
 help
 image-ocp-cli
 images

--- a/make/examples/golang-versions-check/_output/named-golang-versions
+++ b/make/examples/golang-versions-check/_output/named-golang-versions
@@ -1,3 +1,3 @@
+images/Dockerfile-1.16: 1.16
 .ci-operator.yaml: 1.16
 go.mod: 1.16
-images/Dockerfile-1.16: 1.16

--- a/make/operator.example.mk.help.log
+++ b/make/operator.example.mk.help.log
@@ -5,6 +5,7 @@ clean
 clean-binaries
 clean-yaml-patch
 clean-yq
+ensure-imagebuilder
 ensure-yaml-patch
 ensure-yq
 help

--- a/make/targets/openshift/imagebuilder.mk
+++ b/make/targets/openshift/imagebuilder.mk
@@ -1,0 +1,30 @@
+self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+
+IMAGEBUILDER_VERSION ?=1.2.1
+
+IMAGEBUILDER ?= $(shell which imagebuilder 2>/dev/null)
+ifneq "" "$(IMAGEBUILDER)"
+_imagebuilder_installed_version = $(shell $(IMAGEBUILDER) --version)
+endif
+
+# NOTE: We would like to
+#     go get github.com/openshift/imagebuilder/cmd/imagebuilder@v$(IMAGEBUILDER_VERSION)
+# ...but `go get` is too unreliable. So instead we use this to make the
+# "you don't have imagebuilder" error useful.
+ensure-imagebuilder:
+ifeq "" "$(IMAGEBUILDER)"
+	$(error imagebuilder not found! Get it with: `go get github.com/openshift/imagebuilder/cmd/imagebuilder@v$(IMAGEBUILDER_VERSION)`)
+else
+	$(info Using existing imagebuilder from $(IMAGEBUILDER))
+	@[[ $(_imagebuilder_installed_version) == $(IMAGEBUILDER_VERSION) ]] || \
+	echo "Warning: Installed imagebuilder version $(_imagebuilder_installed_version) does not match expected version $(IMAGEBUILDER_VERSION)."
+endif
+.PHONY: ensure-imagebuilder
+
+# We need to be careful to expand all the paths before any include is done
+# or self_dir could be modified for the next include by the included file.
+# Also doing this at the end of the file allows us to use self_dir before it could be modified.
+include $(addprefix $(self_dir), \
+	../../lib/golang.mk \
+	../../lib/tmp.mk \
+)

--- a/make/targets/openshift/images.mk
+++ b/make/targets/openshift/images.mk
@@ -9,7 +9,7 @@ IMAGE_BUILD_EXTRA_FLAGS ?=
 # $3 - Dockerfile path
 # $4 - context
 define build-image-internal
-image-$(1):
+image-$(1): ensure-imagebuilder
 	$(strip \
 		imagebuilder \
 		$(IMAGE_BUILD_DEFAULT_FLAGS) \


### PR DESCRIPTION
make/targets/openshift/images.mk references imagebuilder, which I didn't have. There are other convenient `ensure-*` targets, so I thought I would make one for this.

However, `imagebuilder` is a go tool, and as such should be installed via `go get`, which behaves unreliably/inconsistently depending on the go version, variables, and dependencies in the consuming environment. Therefore, rather than trying to install it automatically, we instead produce a useful error message.

If we find the tool is installed, we check the version and emit a warning if it doesn't match what's expected.

If we like this concept, I'd like to do the same for `kustomize`.