### PR TITLE
make verify-deps should cleanup it's temp directory

### DIFF
--- a/make/targets/openshift/deps-gomod.mk
+++ b/make/targets/openshift/deps-gomod.mk
@@ -24,6 +24,7 @@ verify-deps:
 		echo "If this is an intentional change (a carry patch) please update the 'deps.diff' using 'make update-deps-overrides'." && \
 		false \
 	)
+	rm -rf $(tmp_dir)
 .PHONY: verify-deps
 
 update-deps-overrides: tmp_dir:=$(shell mktemp -d)


### PR DESCRIPTION
`make verify-deps` should cleanup after itself and delete the directory in `/tmp` that it creates.  
When running `make verify-deps` inside of `openshift/origin` it fills up my `/tmp` disk space after two runs.