### PR TITLE
Fix a typo in .PHONY

### DIFF
--- a/make/targets/golang/verify-update.mk
+++ b/make/targets/golang/verify-update.mk
@@ -28,4 +28,4 @@ verify-govet:
 
 verify-golint:
 	$(GOLINT) $(GO_PACKAGES)
-.PHONY: verify-govet
+.PHONY: verify-golint


### PR DESCRIPTION
It should be "verify-golint" and not "verify-govet".