### PR TITLE
`clean-foo` removes all versions of `foo`

### DIFF
--- a/make/examples/multiple-binaries/Makefile.test.log
+++ b/make/examples/multiple-binaries/Makefile.test.log
@@ -17,11 +17,11 @@ make clean
 rm -f oc openshift
 rm -f -r '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/rpms' '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/srpms'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
-rm -f '_output/tools/bin/controller-gen-v0.6.0'
+rm -f _output/tools/bin/controller-gen*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yq-2.4.0'
+rm -f _output/tools/bin/yq*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yaml-patch-v0.0.10'
+rm -f _output/tools/bin/yaml-patch*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
@@ -31,11 +31,11 @@ make clean
 rm -f oc openshift
 rm -f -r '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/rpms' '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/srpms'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
-rm -f '_output/tools/bin/controller-gen-v0.6.0'
+rm -f _output/tools/bin/controller-gen*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yq-2.4.0'
+rm -f _output/tools/bin/yq*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yaml-patch-v0.0.10'
+rm -f _output/tools/bin/yaml-patch*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
@@ -59,11 +59,11 @@ make clean
 rm -f oc openshift
 rm -f -r '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/rpms' '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/srpms'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
-rm -f '_output/tools/bin/controller-gen-v0.6.0'
+rm -f _output/tools/bin/controller-gen*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yq-2.4.0'
+rm -f _output/tools/bin/yq*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yaml-patch-v0.0.10'
+rm -f _output/tools/bin/yaml-patch*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
@@ -72,11 +72,11 @@ make clean
 rm -f oc openshift
 rm -f -r '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/rpms' '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/srpms'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
-rm -f '_output/tools/bin/controller-gen-v0.6.0'
+rm -f _output/tools/bin/controller-gen*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yq-2.4.0'
+rm -f _output/tools/bin/yq*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yaml-patch-v0.0.10'
+rm -f _output/tools/bin/yaml-patch*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
@@ -89,11 +89,11 @@ make clean
 rm -f oc openshift
 rm -f -r '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/rpms' '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/srpms'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
-rm -f '_output/tools/bin/controller-gen-v0.6.0'
+rm -f _output/tools/bin/controller-gen*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yq-2.4.0'
+rm -f _output/tools/bin/yq*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yaml-patch-v0.0.10'
+rm -f _output/tools/bin/yaml-patch*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
@@ -102,11 +102,11 @@ make clean
 rm -f oc openshift
 rm -f -r '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/rpms' '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/srpms'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
-rm -f '_output/tools/bin/controller-gen-v0.6.0'
+rm -f _output/tools/bin/controller-gen*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yq-2.4.0'
+rm -f _output/tools/bin/yq*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yaml-patch-v0.0.10'
+rm -f _output/tools/bin/yaml-patch*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
@@ -188,11 +188,11 @@ make clean
 rm -f oc openshift
 rm -f -r '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/rpms' '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/srpms'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
-rm -f '_output/tools/bin/controller-gen-v0.6.0'
+rm -f _output/tools/bin/controller-gen*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yq-2.4.0'
+rm -f _output/tools/bin/yq*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yaml-patch-v0.0.10'
+rm -f _output/tools/bin/yaml-patch*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
@@ -201,11 +201,11 @@ make clean
 rm -f oc openshift
 rm -f -r '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/rpms' '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/srpms'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
-rm -f '_output/tools/bin/controller-gen-v0.6.0'
+rm -f _output/tools/bin/controller-gen*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yq-2.4.0'
+rm -f _output/tools/bin/yq*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yaml-patch-v0.0.10'
+rm -f _output/tools/bin/yaml-patch*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
@@ -376,11 +376,11 @@ make clean
 rm -f oc openshift
 rm -f -r '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/rpms' '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/srpms'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
-rm -f '_output/tools/bin/controller-gen-v0.6.0'
+rm -f _output/tools/bin/controller-gen*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yq-2.4.0'
+rm -f _output/tools/bin/yq*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yaml-patch-v0.0.10'
+rm -f _output/tools/bin/yaml-patch*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
@@ -389,11 +389,11 @@ make clean
 rm -f oc openshift
 rm -f -r '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/rpms' '/github.com/openshift/build-machinery-go/make/examples/multiple-binaries/_output/srpms'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
-rm -f '_output/tools/bin/controller-gen-v0.6.0'
+rm -f _output/tools/bin/controller-gen*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yq-2.4.0'
+rm -f _output/tools/bin/yq*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
-rm -f '_output/tools/bin/yaml-patch-v0.0.10'
+rm -f _output/tools/bin/yaml-patch*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi

--- a/make/targets/openshift/controller-gen.mk
+++ b/make/targets/openshift/controller-gen.mk
@@ -37,7 +37,7 @@ endif
 .PHONY: ensure-controller-gen
 
 clean-controller-gen:
-	$(RM) '$(CONTROLLER_GEN)'
+	$(RM) $(controller_gen_dir)controller-gen*
 	if [ -d '$(controller_gen_dir)' ]; then rmdir --ignore-fail-on-non-empty -p '$(controller_gen_dir)'; fi
 .PHONY: clean-controller-gen
 

--- a/make/targets/openshift/kustomize.mk
+++ b/make/targets/openshift/kustomize.mk
@@ -20,7 +20,7 @@ endif
 .PHONY: ensure-kustomize
 
 clean-kustomize:
-	$(RM) '$(KUSTOMIZE)'
+	$(RM) $(kustomize_dir)kustomize*
 	if [ -d '$(kustomize_dir)' ]; then rmdir --ignore-fail-on-non-empty -p '$(kustomize_dir)'; fi
 .PHONY: clean-kustomize
 

--- a/make/targets/openshift/yaml-patch.mk
+++ b/make/targets/openshift/yaml-patch.mk
@@ -23,7 +23,7 @@ endif
 .PHONY: ensure-yaml-patch
 
 clean-yaml-patch:
-	$(RM) '$(YAML_PATCH)'
+	$(RM) $(yaml_patch_dir)yaml-patch*
 	if [ -d '$(yaml_patch_dir)' ]; then rmdir --ignore-fail-on-non-empty -p '$(yaml_patch_dir)'; fi
 .PHONY: clean-yaml-patch
 

--- a/make/targets/openshift/yq.mk
+++ b/make/targets/openshift/yq.mk
@@ -23,7 +23,7 @@ endif
 .PHONY: ensure-yq
 
 clean-yq:
-	$(RM) '$(YQ)'
+	$(RM) $(yq_dir)yq*
 	if [ -d '$(yq_dir)' ]; then rmdir --ignore-fail-on-non-empty -p '$(yq_dir)'; fi
 .PHONY: clean-yq
 


### PR DESCRIPTION
We provide a `clean-$foo` target for helper tools -- `$foo` in:
- `controller-gen`
- `kustomize`
- `yaml-patch`
- `yq`

Since #48 / aa83de7 we're installing those helpers to files with versioned names -- e.g. `yq-2.4.0` rather than just `yq` -- so `make clean-yq` would leave behind other versions of `yq`.

With this commit, `make clean-$foo` will remove `${foo}*`, which should lasso all previous versions of a given helper, including one with the unversioned name, which better meets the consumer's expectation of what "clean $foo" should mean.