### PR TITLE
include imagebuilder.mk in image.mk

### DIFF
--- a/make/targets/openshift/images.mk
+++ b/make/targets/openshift/images.mk
@@ -4,6 +4,8 @@
 IMAGE_BUILD_DEFAULT_FLAGS ?=--allow-pull
 IMAGE_BUILD_EXTRA_FLAGS ?=
 
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), imagebuilder.mk)
+
 # $1 - target name
 # $2 - image ref
 # $3 - Dockerfile path


### PR DESCRIPTION
The `image-*` targets depend on the `ensure-imagebuilder` target. Add an `include` statement for `imagebuilder.mk` in `images.mk`  otherwise all existing Makefiles that include `images.mk` need to be updated. See https://github.com/openshift/build-machinery-go/pull/39.