### PR TITLE
Fix versioned ensure-kustomize

### DIFF
--- a/make/targets/openshift/kustomize.mk
+++ b/make/targets/openshift/kustomize.mk
@@ -12,8 +12,13 @@ ensure-kustomize:
 ifeq "" "$(wildcard $(KUSTOMIZE))"
 	$(info Installing kustomize into '$(KUSTOMIZE)')
 	mkdir -p '$(kustomize_dir)'
+	@# install_kustomize.sh lays down the binary as `kustomize`, and will
+	@# also fail if a file of that name already exists. Remove it for
+	@# backward compatibility (older b-m-gs used the raw file name).
+	rm -f $(kustomize_dir)/kustomize
 	@# NOTE: Pinning script to a tag rather than `master` for security reasons
 	curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v$(KUSTOMIZE_VERSION)/hack/install_kustomize.sh"  | bash -s $(KUSTOMIZE_VERSION) $(kustomize_dir)
+	mv $(kustomize_dir)/kustomize $(KUSTOMIZE)
 else
 	$(info Using existing kustomize from "$(KUSTOMIZE)")
 endif


### PR DESCRIPTION
aa83de7d / #48 added versioning for helper binaries. However, for kustomize, it assumed the install script would create the binary with the versioned name, which it doesn't. So consumers trying to use `$(KUSTOMIZE)`, which will be `_output/tools/bin/kustomize-v4.1.3`, will fail because it's actually at `_output/tools/bin/kustomize`.

Furthermore, running `make ensure-kustomize` twice will cause the install script to fail because its target file already exists.

Fix.