### PR TITLE
go_version: allow for versions with two components

### DIFF
--- a/make/lib/golang.mk
+++ b/make/lib/golang.mk
@@ -16,7 +16,7 @@ GOFMT ?=gofmt
 GOFMT_FLAGS ?=-s -l
 GOLINT ?=golint
 
-go_version :=$(shell $(GO) version | sed -E -e 's/.*go([0-9]+.[0-9]+.[0-9]+).*/\1/')
+go_version :=$(shell $(GO) version | sed -E -e 's/.*go([0-9]+.[0-9]+(.[0-9]+)?).*/\1/')
 GO_REQUIRED_MIN_VERSION ?=1.15.2
 ifneq "$(GO_REQUIRED_MIN_VERSION)" ""
 $(call require_minimal_version,$(GO),GO_REQUIRED_MIN_VERSION,$(go_version))


### PR DESCRIPTION
go1.16 reports itself as

    go version go1.16 linux/amd64

which the sed expression used for go_version fails to recognise.

This patch makes the third component optional.

Signed-off-by: Stephen Kitt <skitt@redhat.com>