### PR TITLE
Bump controller-gen to v0.7.0 to match openshift/api

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-8-release-golang-1.17-openshift-4.10

--- a/make/examples/multiple-binaries/Makefile.test.log
+++ b/make/examples/multiple-binaries/Makefile.test.log
@@ -126,47 +126,58 @@ mkdir -p '_output/tools/bin/'
 curl -s -f -L https://github.com/pivotal-cf/yaml-patch/releases/download/v0.0.11/yaml_patch_linux -o '_output/tools/bin/yaml-patch-v0.0.11'
 chmod +x '_output/tools/bin/yaml-patch-v0.0.11';
 --- ./manifests/operator.openshift.io_myotheroperatorresources.crd.yaml
-@@ -9,6 +9,40 @@ spec:
+@@ -9,9 +9,51 @@ spec:
      kind: MyOtherOperatorResource
      plural: myotheroperatorresources
    scope: ""
 +  validation:
 +    openAPIV3Schema:
-+      description: MyOtherOperatorResource is an example operator configuration type
 +      properties:
-+        apiVersion:
-+          description: 'APIVersion defines the versioned schema of this representation
-+            of an object. Servers should convert recognized schemas to the latest
-+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-+          type: string
-+        kind:
-+          description: 'Kind is a string value representing the REST resource this
-+            object represents. Servers may infer this from the endpoint the client
-+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-+          type: string
-+        metadata:
-+          type: object
 +        spec:
 +          properties:
-+            deprecatedField:
-+              type: string
-+            name:
-+              type: string
 +            overwritePattern:
 +              pattern: ^(Managed|Unmanaged)$
-+              type: string
-+          required:
-+          - deprecatedField
-+          - name
-+          - overwritePattern
-+          type: object
-+      required:
-+      - metadata
-+      - spec
-+      type: object
    version: v1beta1
    versions:
    - name: v1beta1
++    schema:
++      openAPIV3Schema:
++        description: MyOtherOperatorResource is an example operator configuration
++          type
++        properties:
++          apiVersion:
++            description: 'APIVersion defines the versioned schema of this representation
++              of an object. Servers should convert recognized schemas to the latest
++              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
++            type: string
++          kind:
++            description: 'Kind is a string value representing the REST resource this
++              object represents. Servers may infer this from the endpoint the client
++              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
++            type: string
++          metadata:
++            type: object
++          spec:
++            properties:
++              deprecatedField:
++                type: string
++              name:
++                type: string
++              overwritePattern:
++                pattern: ^(Managed|Unmanaged)$
++                type: string
++            required:
++            - deprecatedField
++            - name
++            - overwritePattern
++            type: object
++        required:
++        - metadata
++        - spec
++        type: object
+     served: true
+     storage: true
+ status:
 make[2]: *** [verify-codegen-crds-manifests] Error 1
 make update-codegen-crds
 Using existing controller-gen from "_output/tools/bin/controller-gen-v0.7.0"

--- a/make/examples/multiple-binaries/Makefile.test.log
+++ b/make/examples/multiple-binaries/Makefile.test.log
@@ -113,10 +113,10 @@ if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
 cp -r ./testing/manifests/initial/* ./manifests/
 diff -Naup ./testing/manifests/initial/ ./manifests/
 ! make verify-codegen-crds
-Installing controller-gen into '_output/tools/bin/controller-gen-v0.6.0'
+Installing controller-gen into '_output/tools/bin/controller-gen-v0.7.0'
 mkdir -p '_output/tools/bin/'
-curl -s -f -L https://github.com/openshift/kubernetes-sigs-controller-tools/releases/download/v0.6.0/controller-gen-linux-amd64 -o '_output/tools/bin/controller-gen-v0.6.0'
-chmod +x '_output/tools/bin/controller-gen-v0.6.0';
+curl -s -f -L https://github.com/openshift/kubernetes-sigs-controller-tools/releases/download/v0.7.0/controller-gen-linux-amd64 -o '_output/tools/bin/controller-gen-v0.7.0'
+chmod +x '_output/tools/bin/controller-gen-v0.7.0';
 Installing yq into '_output/tools/bin/yq-2.4.0'
 mkdir -p '_output/tools/bin/'
 curl -s -f -L https://github.com/mikefarah/yq/releases/download/2.4.0/yq_linux_amd64 -o '_output/tools/bin/yq-2.4.0'
@@ -169,16 +169,16 @@ chmod +x '_output/tools/bin/yaml-patch-v0.0.11';
    - name: v1beta1
 make[2]: *** [verify-codegen-crds-manifests] Error 1
 make update-codegen-crds
-Using existing controller-gen from "_output/tools/bin/controller-gen-v0.6.0"
+Using existing controller-gen from "_output/tools/bin/controller-gen-v0.7.0"
 Using existing yq from "_output/tools/bin/yq-2.4.0"
 Using existing yaml-patch from "_output/tools/bin/yaml-patch-v0.0.11"
-'_output/tools/bin/controller-gen-v0.6.0' schemapatch:manifests="./manifests" paths="./pkg/apis/v1;./pkg/apis/v1beta1" output:dir="./manifests"
+'_output/tools/bin/controller-gen-v0.7.0' schemapatch:manifests="./manifests" paths="./pkg/apis/v1;./pkg/apis/v1beta1" output:dir="./manifests"
 _output/tools/bin/yq-2.4.0 m -i -x './manifests/operator.openshift.io_myotheroperatorresources.crd.yaml' './manifests/operator.openshift.io_myotheroperatorresources.crd.yaml-merge-patch'
 _output/tools/bin/yq-2.4.0 m -i -x './manifests/operator.openshift.io_myoperatorresources.crd.yaml' './manifests/operator.openshift.io_myoperatorresources.crd.yaml-merge-patch'
 _output/tools/bin/yaml-patch-v0.0.11 -o './manifests/operator.openshift.io_myv1resources.crd.yaml-patch' < './manifests/operator.openshift.io_myv1resources.crd.yaml' > './manifests/operator.openshift.io_myv1resources.crd.yaml.patched'
 mv './manifests/operator.openshift.io_myv1resources.crd.yaml.patched' './manifests/operator.openshift.io_myv1resources.crd.yaml'
 make verify-codegen-crds
-Using existing controller-gen from "_output/tools/bin/controller-gen-v0.6.0"
+Using existing controller-gen from "_output/tools/bin/controller-gen-v0.7.0"
 Using existing yq from "_output/tools/bin/yq-2.4.0"
 Using existing yaml-patch from "_output/tools/bin/yaml-patch-v0.0.11"
 cp -r ./testing/manifests/initial/*.crd.yaml{-merge-patch,-patch} ./manifests/

--- a/make/examples/multiple-binaries/manifests/operator.openshift.io_myoperatorresources.crd.yaml
+++ b/make/examples/multiple-binaries/manifests/operator.openshift.io_myoperatorresources.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null

--- a/make/examples/multiple-binaries/manifests/operator.openshift.io_myotheroperatorresources.crd.yaml
+++ b/make/examples/multiple-binaries/manifests/operator.openshift.io_myotheroperatorresources.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null

--- a/make/examples/multiple-binaries/manifests/operator.openshift.io_myotheroperatorresources.crd.yaml
+++ b/make/examples/multiple-binaries/manifests/operator.openshift.io_myotheroperatorresources.crd.yaml
@@ -11,41 +11,49 @@ spec:
   scope: ""
   validation:
     openAPIV3Schema:
-      description: MyOtherOperatorResource is an example operator configuration type
       properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
         spec:
           properties:
-            deprecatedField:
-              type: string
-            name:
-              type: string
             overwritePattern:
               pattern: ^(Managed|Unmanaged)$
-              type: string
-          required:
-          - deprecatedField
-          - name
-          - overwritePattern
-          type: object
-      required:
-      - metadata
-      - spec
-      type: object
   version: v1beta1
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MyOtherOperatorResource is an example operator configuration
+          type
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              deprecatedField:
+                type: string
+              name:
+                type: string
+              overwritePattern:
+                pattern: ^(Managed|Unmanaged)$
+                type: string
+            required:
+            - deprecatedField
+            - name
+            - overwritePattern
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
     served: true
     storage: true
 status:

--- a/make/examples/multiple-binaries/testing/manifests/initial/operator.openshift.io_myoperatorresources.crd.yaml
+++ b/make/examples/multiple-binaries/testing/manifests/initial/operator.openshift.io_myoperatorresources.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null

--- a/make/examples/multiple-binaries/testing/manifests/initial/operator.openshift.io_myotheroperatorresources.crd.yaml
+++ b/make/examples/multiple-binaries/testing/manifests/initial/operator.openshift.io_myotheroperatorresources.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null

--- a/make/examples/multiple-binaries/testing/manifests/updated/operator.openshift.io_myoperatorresources.crd.yaml
+++ b/make/examples/multiple-binaries/testing/manifests/updated/operator.openshift.io_myoperatorresources.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null

--- a/make/examples/multiple-binaries/testing/manifests/updated/operator.openshift.io_myotheroperatorresources.crd.yaml
+++ b/make/examples/multiple-binaries/testing/manifests/updated/operator.openshift.io_myotheroperatorresources.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null

--- a/make/examples/multiple-binaries/testing/manifests/updated/operator.openshift.io_myotheroperatorresources.crd.yaml
+++ b/make/examples/multiple-binaries/testing/manifests/updated/operator.openshift.io_myotheroperatorresources.crd.yaml
@@ -11,41 +11,49 @@ spec:
   scope: ""
   validation:
     openAPIV3Schema:
-      description: MyOtherOperatorResource is an example operator configuration type
       properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
         spec:
           properties:
-            deprecatedField:
-              type: string
-            name:
-              type: string
             overwritePattern:
               pattern: ^(Managed|Unmanaged)$
-              type: string
-          required:
-          - deprecatedField
-          - name
-          - overwritePattern
-          type: object
-      required:
-      - metadata
-      - spec
-      type: object
   version: v1beta1
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MyOtherOperatorResource is an example operator configuration
+          type
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              deprecatedField:
+                type: string
+              name:
+                type: string
+              overwritePattern:
+                pattern: ^(Managed|Unmanaged)$
+                type: string
+            required:
+            - deprecatedField
+            - name
+            - overwritePattern
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
     served: true
     storage: true
 status:

--- a/make/targets/openshift/controller-gen.mk
+++ b/make/targets/openshift/controller-gen.mk
@@ -8,7 +8,7 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 # reporting `(devel)`. To build for a given platform:
 # 	GOOS=xxx GOARCH=yyy go install sigs.k8s.io/controller-tools/cmd/controller-gen@$version
 # e.g.
-# 	GOOS=darwin GOARCH=amd64 go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.0
+# 	GOOS=darwin GOARCH=amd64 go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0
 #
 # If GOOS and GOARCH match your current go env, this will install the binary at
 # 	$(go env GOPATH)/bin/controller-gen
@@ -16,7 +16,7 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 # 	$(go env GOPATH)/bin/${GOOS}_${GOARCH}/conroller-gen
 # e.g.
 # 	/home/efried/.gvm/pkgsets/go1.16/global/bin/darwin_amd64/controller-gen
-CONTROLLER_GEN_VERSION ?=v0.6.0
+CONTROLLER_GEN_VERSION ?=v0.7.0
 CONTROLLER_GEN ?=$(PERMANENT_TMP_GOPATH)/bin/controller-gen-$(CONTROLLER_GEN_VERSION)
 ifneq "" "$(wildcard $(CONTROLLER_GEN))"
 _controller_gen_installed_version = $(shell $(CONTROLLER_GEN) --version | awk '{print $$2}')


### PR DESCRIPTION
We bumped controller-gen in https://github.com/openshift/api/pull/1016 but this one was still using 0.6, we should align those. 

/assign @sttts