### PR TITLE
make/targets/openshift/crd-schema-gen: In-place verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ examples :=$(wildcard ./make/examples/*/Makefile.test)
 
 # $1 - makefile name relative to ./make/ folder
 # $2 - target
-# $3 - output folder
 # We need to change dir to the final makefile directory or relative paths won't match.
 # Dynamic values are replaced with "<redacted_for_diff>" so we can do diff against checkout versions.
 # Avoid comparing local paths by stripping the prefix.
@@ -16,39 +15,36 @@ examples :=$(wildcard ./make/examples/*/Makefile.test)
 # Ignore old cp errors on centos7
 # Ignore different make output with `-k` option
 define update-makefile-log
-mkdir -p "$(3)"
-set -o pipefail; $(MAKE) -j 1 -C "$(dir $(1))" -f "$(notdir $(1))" --no-print-directory --warn-undefined-variables $(2) 2>&1 | \
-   sed 's/\.\(buildDate\|versionFromGit\|commitFromGit\|gitTreeState\)="[^"]*" /.\1="<redacted_for_diff>" /g' | \
+set -o pipefail; $(MAKE) -j 1 -C "$(dir $(1))" -f "$(notdir $(1))" --no-print-directory --warn-undefined-variables $(2) > "$(1)$(subst ..,.,.$(2).log.raw)" 2>&1 || (cat "$(1)$(subst ..,.,.$(2).log.raw)" && exit 1)
+sed 's/\.\(buildDate\|versionFromGit\|commitFromGit\|gitTreeState\)="[^"]*" /.\1="<redacted_for_diff>" /g' "$(1)$(subst ..,.,.$(2).log.raw)" | \
    sed -E 's~/[^ ]*/(github.com/openshift/build-machinery-go/[^ ]*)~/\1~g' | \
    sed '/\/tmp\/tmp./d' | \
    sed '/git checkout -b/d' | \
    sed -E 's~^[<> ]*((\+\+\+|\-\-\-) \./(testing/)?manifests/.*.yaml).*~\1~' | \
    sed -E 's/^(make\[2\]: \*\*\* \[).*: (.*\] Error 1)/\1\2/' | \
    grep -v 'are the same file' | \
-   grep -E -v -e '^make\[2\]: Target `.*'"'"' not remade because of errors\.$$' | \
-   tee "$(3)"/"$(notdir $(1))"$(subst ..,.,.$(2).log)
+   grep -E -v -e '^make\[2\]: Target `.*'"'"' not remade because of errors\.$$' \
+   > "$(1)$(subst ..,.,.$(2).log)"
 
 endef
 
 
 # $1 - makefile name relative to ./make/ folder
 # $2 - target
-# $3 - output folder
 define check-makefile-log
-$(call update-makefile-log,$(1),$(2),$(3))
-diff -N "$(1)$(subst ..,.,.$(2).log)" "$(3)/$(notdir $(1))$(subst ..,.,.$(2).log)"
+$(call update-makefile-log,$(1),$(2))
+git diff --exit-code
 
 endef
 
 update-makefiles:
-	$(foreach f,$(makefiles),$(call check-makefile-log,$(f),help,$(dir $(f))))
-	$(foreach f,$(examples),$(call check-makefile-log,$(f),,$(dir $(f))))
+	$(foreach f,$(makefiles),$(call check-makefile-log,$(f),help))
+	$(foreach f,$(examples),$(call check-makefile-log,$(f),))
 .PHONY: update-makefiles
 
-verify-makefiles: tmp_dir:=$(shell mktemp -d)
 verify-makefiles:
-	$(foreach f,$(makefiles),$(call check-makefile-log,$(f),help,$(tmp_dir)/$(dir $(f))))
-	$(foreach f,$(examples),$(call check-makefile-log,$(f),,$(tmp_dir)/$(dir $(f))))
+	$(foreach f,$(makefiles),$(call check-makefile-log,$(f),help))
+	$(foreach f,$(examples),$(call check-makefile-log,$(f),))
 .PHONY: verify-makefiles
 
 verify: verify-makefiles

--- a/make/examples/multiple-binaries/Makefile
+++ b/make/examples/multiple-binaries/Makefile
@@ -19,8 +19,7 @@ RPM_EXTRAFLAGS :=--quiet --define 'version 2.42.0' --define 'dist .el7' --define
 # $1 - target name
 # $2 - apis
 # $3 - manifests
-# $4 - output
-$(call add-crd-gen,manifests,$(CRD_APIS),./manifests,./manifests)
+$(call add-crd-gen,manifests,$(CRD_APIS),./manifests)
 
 # $1 - target name
 # $2 - profile patches dir

--- a/make/examples/multiple-binaries/Makefile.test
+++ b/make/examples/multiple-binaries/Makefile.test
@@ -54,10 +54,12 @@ test-rpm:
 
 test-codegen:
 	cp -r ./testing/manifests/initial/* ./manifests/
+	git add --no-ignore-removal ./manifests/
 	diff -Naup ./testing/manifests/initial/ ./manifests/
 	! $(MAKE) verify-codegen-crds
 
 	$(MAKE) update-codegen-crds
+	git add --no-ignore-removal ./manifests/
 	$(MAKE) verify-codegen-crds
 	cp -r ./testing/manifests/initial/*.crd.yaml{-merge-patch,-patch} ./manifests/
 	! diff -Naup ./testing/manifests/initial/ ./manifests/ 2>/dev/null 1>&2
@@ -66,6 +68,7 @@ test-codegen:
 	$(MAKE) clean
 	[[ ! -d ./_output/ ]] || (ls -l ./_output/ && false)
 	$(MAKE) clean
+	git add --no-ignore-removal ./manifests/
 .PHONY: test-codegen
 
 test-profile-manifests:

--- a/make/examples/multiple-binaries/Makefile.test.log
+++ b/make/examples/multiple-binaries/Makefile.test.log
@@ -111,6 +111,7 @@ if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_outpu
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
 cp -r ./testing/manifests/initial/* ./manifests/
+git add --no-ignore-removal ./manifests/
 diff -Naup ./testing/manifests/initial/ ./manifests/
 ! make verify-codegen-crds
 Installing controller-gen into '_output/tools/bin/controller-gen-v0.7.0'
@@ -125,7 +126,32 @@ Installing yaml-patch into '_output/tools/bin/yaml-patch-v0.0.11'
 mkdir -p '_output/tools/bin/'
 curl -s -f -L https://github.com/pivotal-cf/yaml-patch/releases/download/v0.0.11/yaml_patch_linux -o '_output/tools/bin/yaml-patch-v0.0.11'
 chmod +x '_output/tools/bin/yaml-patch-v0.0.11';
---- ./manifests/operator.openshift.io_myotheroperatorresources.crd.yaml
+'_output/tools/bin/controller-gen-v0.7.0' schemapatch:manifests="./manifests" paths="./pkg/apis/v1;./pkg/apis/v1beta1" 'output:dir="./manifests"'
+_output/tools/bin/yq-2.4.0 m -i -x './manifests/operator.openshift.io_myotheroperatorresources.crd.yaml' './manifests/operator.openshift.io_myotheroperatorresources.crd.yaml-merge-patch'
+_output/tools/bin/yq-2.4.0 m -i -x './manifests/operator.openshift.io_myoperatorresources.crd.yaml' './manifests/operator.openshift.io_myoperatorresources.crd.yaml-merge-patch'
+_output/tools/bin/yaml-patch-v0.0.11 -o './manifests/operator.openshift.io_myv1resources.crd.yaml-patch' < './manifests/operator.openshift.io_myv1resources.crd.yaml' > './manifests/operator.openshift.io_myv1resources.crd.yaml.patched'
+mv './manifests/operator.openshift.io_myv1resources.crd.yaml.patched' './manifests/operator.openshift.io_myv1resources.crd.yaml'
+git diff --exit-code
+diff --git a/make/examples/multiple-binaries/manifests/operator.openshift.io_myoperatorresources.crd.yaml b/make/examples/multiple-binaries/manifests/operator.openshift.io_myoperatorresources.crd.yaml
+index 8c33cbb..77e7f4d 100644
+--- a/make/examples/multiple-binaries/manifests/operator.openshift.io_myoperatorresources.crd.yaml
++++ b/make/examples/multiple-binaries/manifests/operator.openshift.io_myoperatorresources.crd.yaml
+@@ -9,6 +9,11 @@ spec:
+     kind: MyOperatorResource
+     plural: myoperatorresources
+   scope: ""
++  validation:
++    openAPIV3Schema:
++      properties:
++        apiVersion:
++          pattern: ^(test|TEST)$
+ status:
+   acceptedNames:
+     kind: ""
+diff --git a/make/examples/multiple-binaries/manifests/operator.openshift.io_myotheroperatorresources.crd.yaml b/make/examples/multiple-binaries/manifests/operator.openshift.io_myotheroperatorresources.crd.yaml
+index d21f2e0..b5d2b6c 100644
+--- a/make/examples/multiple-binaries/manifests/operator.openshift.io_myotheroperatorresources.crd.yaml
++++ b/make/examples/multiple-binaries/manifests/operator.openshift.io_myotheroperatorresources.crd.yaml
 @@ -9,9 +9,51 @@ spec:
      kind: MyOtherOperatorResource
      plural: myotheroperatorresources
@@ -178,6 +204,49 @@ chmod +x '_output/tools/bin/yaml-patch-v0.0.11';
      served: true
      storage: true
  status:
+diff --git a/make/examples/multiple-binaries/manifests/operator.openshift.io_myv1resources.crd.yaml b/make/examples/multiple-binaries/manifests/operator.openshift.io_myv1resources.crd.yaml
+index 59fd04a..5af3182 100644
+--- a/make/examples/multiple-binaries/manifests/operator.openshift.io_myv1resources.crd.yaml
++++ b/make/examples/multiple-binaries/manifests/operator.openshift.io_myv1resources.crd.yaml
+@@ -12,9 +12,37 @@ spec:
+   - name: v1
+     schema:
+       openAPIV3Schema:
++        description: MyV1Resource is an example operator configuration type
+         properties:
+           apiVersion:
+-            pattern: ^(test|TEST)$
++            description: 'APIVersion defines the versioned schema of this representation
++              of an object. Servers should convert recognized schemas to the latest
++              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
++            type: string
++          kind:
++            description: 'Kind is a string value representing the REST resource this
++              object represents. Servers may infer this from the endpoint the client
++              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
++            type: string
++          metadata:
++            properties:
++              name:
++                enum:
++                - a
++                - b
++                type: string
++            type: object
++          spec:
++            properties:
++              name:
++                type: string
++            required:
++            - name
++            type: object
++        required:
++        - metadata
++        - spec
++        type: object
+     served: true
+     storage: true
+     subresources:
 make[2]: *** [verify-codegen-crds-manifests] Error 1
 make update-codegen-crds
 Using existing controller-gen from "_output/tools/bin/controller-gen-v0.7.0"
@@ -188,10 +257,17 @@ _output/tools/bin/yq-2.4.0 m -i -x './manifests/operator.openshift.io_myotherope
 _output/tools/bin/yq-2.4.0 m -i -x './manifests/operator.openshift.io_myoperatorresources.crd.yaml' './manifests/operator.openshift.io_myoperatorresources.crd.yaml-merge-patch'
 _output/tools/bin/yaml-patch-v0.0.11 -o './manifests/operator.openshift.io_myv1resources.crd.yaml-patch' < './manifests/operator.openshift.io_myv1resources.crd.yaml' > './manifests/operator.openshift.io_myv1resources.crd.yaml.patched'
 mv './manifests/operator.openshift.io_myv1resources.crd.yaml.patched' './manifests/operator.openshift.io_myv1resources.crd.yaml'
+git add --no-ignore-removal ./manifests/
 make verify-codegen-crds
 Using existing controller-gen from "_output/tools/bin/controller-gen-v0.7.0"
 Using existing yq from "_output/tools/bin/yq-2.4.0"
 Using existing yaml-patch from "_output/tools/bin/yaml-patch-v0.0.11"
+'_output/tools/bin/controller-gen-v0.7.0' schemapatch:manifests="./manifests" paths="./pkg/apis/v1;./pkg/apis/v1beta1" 'output:dir="./manifests"'
+_output/tools/bin/yq-2.4.0 m -i -x './manifests/operator.openshift.io_myotheroperatorresources.crd.yaml' './manifests/operator.openshift.io_myotheroperatorresources.crd.yaml-merge-patch'
+_output/tools/bin/yq-2.4.0 m -i -x './manifests/operator.openshift.io_myoperatorresources.crd.yaml' './manifests/operator.openshift.io_myoperatorresources.crd.yaml-merge-patch'
+_output/tools/bin/yaml-patch-v0.0.11 -o './manifests/operator.openshift.io_myv1resources.crd.yaml-patch' < './manifests/operator.openshift.io_myv1resources.crd.yaml' > './manifests/operator.openshift.io_myv1resources.crd.yaml.patched'
+mv './manifests/operator.openshift.io_myv1resources.crd.yaml.patched' './manifests/operator.openshift.io_myv1resources.crd.yaml'
+git diff --exit-code
 cp -r ./testing/manifests/initial/*.crd.yaml{-merge-patch,-patch} ./manifests/
 ! diff -Naup ./testing/manifests/initial/ ./manifests/ 2>/dev/null 1>&2
 diff -Naup ./testing/manifests/updated/ ./manifests/
@@ -220,6 +296,7 @@ rm -f _output/tools/bin/yaml-patch*
 if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
 rm -f -r '_output/bin'
 if [ -d '_output' ]; then rmdir --ignore-fail-on-non-empty '_output'; fi
+git add --no-ignore-removal ./manifests/
 rm -f ./profile-manifests-1/* ./profile-manifests-2/*
 cp ./testing/profile-manifests/initial/* ./profile-manifests-1/
 cp ./testing/profile-manifests/initial/* ./profile-manifests-2/

--- a/make/targets/openshift/crd-schema-gen.mk
+++ b/make/targets/openshift/crd-schema-gen.mk
@@ -23,41 +23,32 @@ endef
 
 empty :=
 
-define diff-file
-	diff -Naup '$(1)' '$(2)'
-
-endef
-
 # $1 - apis
 # $2 - manifests
-# $3 - output
 define run-crd-gen
 	'$(CONTROLLER_GEN)' \
 		schemapatch:manifests="$(2)" \
 		paths="$(subst $(empty) ,;,$(1))" \
-		'output:dir="$(3)"'
-	$$(foreach p,$$(wildcard $(2)/*.crd.yaml-merge-patch),$$(call patch-crd-yq,$$(subst $(2),$(3),$$(basename $$(p))).yaml,$$(p)))
-	$$(foreach p,$$(wildcard $(2)/*.crd.yaml-patch),$$(call patch-crd-yaml-patch,$$(subst $(2),$(3),$$(basename $$(p))).yaml,$$(p)))
+		'output:dir="$(2)"'
+	$$(foreach p,$$(wildcard $(2)/*.crd.yaml-merge-patch),$$(call patch-crd-yq,$$(basename $$(p)).yaml,$$(p)))
+	$$(foreach p,$$(wildcard $(2)/*.crd.yaml-patch),$$(call patch-crd-yaml-patch,$$(basename $$(p)).yaml,$$(p)))
 endef
 
 
 # $1 - target name
 # $2 - apis
 # $3 - manifests
-# $4 - output
 define add-crd-gen-internal
 
 update-codegen-crds-$(1): ensure-controller-gen ensure-yq ensure-yaml-patch
-	$(call run-crd-gen,$(2),$(3),$(4))
+	$(call run-crd-gen,$(2),$(3))
 .PHONY: update-codegen-crds-$(1)
 
 update-codegen-crds: update-codegen-crds-$(1)
 .PHONY: update-codegen-crds
 
-verify-codegen-crds-$(1): VERIFY_CODEGEN_CRD_TMP_DIR:=$$(shell mktemp -d)
-verify-codegen-crds-$(1): ensure-controller-gen ensure-yq ensure-yaml-patch
-	$(call run-crd-gen,$(2),$(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR))
-	$$(foreach p,$$(wildcard $(4)/*crd.yaml),$$(call diff-file,$$(p),$$(subst $(4),$$(VERIFY_CODEGEN_CRD_TMP_DIR),$$(p))))
+verify-codegen-crds-$(1): update-codegen-crds-$(1)
+	git diff --exit-code
 .PHONY: verify-codegen-crds-$(1)
 
 verify-codegen-crds: verify-codegen-crds-$(1)
@@ -80,5 +71,5 @@ verify: verify-generated
 
 
 define add-crd-gen
-$(eval $(call add-crd-gen-internal,$(1),$(2),$(3),$(4)))
+$(eval $(call add-crd-gen-internal,$(1),$(2),$(3)))
 endef


### PR DESCRIPTION
Being able to generate output into an alternative, possibly temporary, directory is interesting, but it makes for output [like][1]:

```
...
diff -Naup './config/v1/0000_10_config-operator_01_ingress.crd.yaml' '/tmp/tmp.uG3ZAq6abW/0000_10_config-operator_01_ingress.crd.yaml'
diff -Naup './config/v1/0000_03_config-operator_01_proxy.crd.yaml' '/tmp/tmp.uG3ZAq6abW/0000_03_config-operator_01_proxy.crd.yaml'
...many lines of no-diff noise...
--- ./operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml	2022-03-09 21:33:08.000000000 +0000
+++ /tmp/tmp.4pZalfGr2h/0000_90_cluster_csi_driver_01_config.crd.yaml	2022-03-09 21:36:30.265253548 +0000
@@ -51,6 +51,7 @@ spec:
                 - csi.sharedresource.openshift.io
                 - diskplugin.csi.alibabacloud.com
                 - vpc.block.csi.ibm.io
+                - csi.nutanix.com
                 type: string
             type: object
           spec:
make: *** [Makefile:35: verify-codegen-crds-operator] Error 1
...
```

By pivoting to an in-place verification, we get a few benefits:

* It will only complain about files which have actually changed.  No more no-diff noise.
* It will include all the files that need patching.  No more failing out after the first divergent manifest.
* When run locally, the code is automatically updated :).
* When run in CI, the output patch can be applied with `git apply ...`, because it doesn't have the `/tmp/...` prefix business.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_api/1138/pull-ci-openshift-api-master-verify/1501672124027244544#1:build-log.txt%3A112