### PR TITLE
Make git tag contain git commit if matching the tag failed

### DIFF
--- a/make/lib/golang.mk
+++ b/make/lib/golang.mk
@@ -50,7 +50,7 @@ GO_TEST_FLAGS ?=-race
 
 GO_LD_EXTRAFLAGS ?=
 
-SOURCE_GIT_TAG ?=$(shell git describe --long --tags --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown')
+SOURCE_GIT_TAG ?=$(shell git describe --long --tags --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown-$(SOURCE_GIT_COMMIT)')
 SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)
 SOURCE_GIT_TREE_STATE ?=$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty')
 


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>

Now if `git describe --long --tags --abbrev=7 --match 'v[0-9]*'` failed, when we execute a command, output will be
```
testcommand --version
testcommand version v0.0.0-unknown
```

This commit makes it to be:
```
testcommand --version
testcommand version v0.0.0-unknown-85affa2f
```