### PR TITLE
Single-quote output:dir controller-gen option.

### DIFF
--- a/make/examples/multiple-binaries/Makefile.test.log
+++ b/make/examples/multiple-binaries/Makefile.test.log
@@ -183,7 +183,7 @@ make update-codegen-crds
 Using existing controller-gen from "_output/tools/bin/controller-gen-v0.7.0"
 Using existing yq from "_output/tools/bin/yq-2.4.0"
 Using existing yaml-patch from "_output/tools/bin/yaml-patch-v0.0.11"
-'_output/tools/bin/controller-gen-v0.7.0' schemapatch:manifests="./manifests" paths="./pkg/apis/v1;./pkg/apis/v1beta1" output:dir="./manifests"
+'_output/tools/bin/controller-gen-v0.7.0' schemapatch:manifests="./manifests" paths="./pkg/apis/v1;./pkg/apis/v1beta1" 'output:dir="./manifests"'
 _output/tools/bin/yq-2.4.0 m -i -x './manifests/operator.openshift.io_myotheroperatorresources.crd.yaml' './manifests/operator.openshift.io_myotheroperatorresources.crd.yaml-merge-patch'
 _output/tools/bin/yq-2.4.0 m -i -x './manifests/operator.openshift.io_myoperatorresources.crd.yaml' './manifests/operator.openshift.io_myoperatorresources.crd.yaml-merge-patch'
 _output/tools/bin/yaml-patch-v0.0.11 -o './manifests/operator.openshift.io_myv1resources.crd.yaml-patch' < './manifests/operator.openshift.io_myv1resources.crd.yaml' > './manifests/operator.openshift.io_myv1resources.crd.yaml.patched'

--- a/make/targets/openshift/crd-schema-gen.mk
+++ b/make/targets/openshift/crd-schema-gen.mk
@@ -35,7 +35,7 @@ define run-crd-gen
 	'$(CONTROLLER_GEN)' \
 		schemapatch:manifests="$(2)" \
 		paths="$(subst $(empty) ,;,$(1))" \
-		output:dir="$(3)"
+		'output:dir="$(3)"'
 	$$(foreach p,$$(wildcard $(2)/*.crd.yaml-merge-patch),$$(call patch-crd-yq,$$(subst $(2),$(3),$$(basename $$(p))).yaml,$$(p)))
 	$$(foreach p,$$(wildcard $(2)/*.crd.yaml-patch),$$(call patch-crd-yaml-patch,$$(subst $(2),$(3),$$(basename $$(p))).yaml,$$(p)))
 endef


### PR DESCRIPTION
The first argument of the shell invocation `controller-gen output:dir="foo"` reaches controller-gen as output:dir=foo. Without
the quotes, certain values for output:dir confuse controller-gen's option parsing as it attempts to guess the value's type.

For example:

```
$ controller-gen output:dir="/tmp/tmp.1Pbg8eLCZK" # interpreted as an invalid floating-point number
Error: unable to parse option "output:dir=/tmp/tmp.1Pbg8eLCZK": ['P' exponent requires hexadecimal mantissa (at <input>:1:9) exponent has no digits (at <input>:1:9)]
```