### PR TITLE
add the ability for techpreview generation per api group

### DIFF
--- a/make/targets/openshift/crd-schema-gen.mk
+++ b/make/targets/openshift/crd-schema-gen.mk
@@ -57,6 +57,28 @@ verify-codegen-crds: verify-codegen-crds-$(1)
 endef
 
 
+# $1 - target name
+# $2 - apis
+# $3 - manifests
+# $4 - featureSet
+define add-crd-gen-for-featureset-internal
+
+update-codegen-$(4)-crds-$(1): ensure-controller-gen ensure-yq ensure-yaml-patch
+	OPENSHIFT_REQUIRED_FEATURESET=$(4) $(call run-crd-gen,$(2),$(3))
+.PHONY: update-codegen-$(4)-crds-$(1)
+
+update-codegen-$(4)-crds: update-codegen-$(4)-crds-$(1)
+.PHONY: update-codegen-$(4)-crds
+
+verify-codegen-$(4)-crds-$(1): update-codegen-$(4)-crds-$(1)
+	git diff --exit-code
+.PHONY: verify-codegen-$(4)-crds-$(1)
+
+verify-codegen-$(4)-crds: verify-codegen-$(4)-crds-$(1)
+.PHONY: verify-codegen-$(4)-crds
+
+endef
+
 update-generated: update-codegen-crds
 .PHONY: update-generated
 
@@ -73,3 +95,8 @@ verify: verify-generated
 define add-crd-gen
 $(eval $(call add-crd-gen-internal,$(1),$(2),$(3)))
 endef
+
+define add-crd-gen-for-featureset
+$(eval $(call add-crd-gen-for-featureset-internal,$(1),$(2),$(3),$(5)))
+endef
+


### PR DESCRIPTION
This lets someone create 

`$(call add-crd-gen-for-featureset,example-alpha,./example/v1alpha1,./example/v1alpha1,./example/v1alpha1,TechPreviewNoUpgrade)`

in their Makefile.  This is the simplest thing that can work.  The securityinternal group has a patch file that does a remove.  We really want the patch target to skip files that don't match the featureset, but I can't figure out how to do that.  I don't want to block the overall feature on perfect makefile work.