### PR TITLE
golang/test-unit: add go test args

### DIFF
--- a/make/targets/golang/test-unit.mk
+++ b/make/targets/golang/test-unit.mk
@@ -4,11 +4,11 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 
 test-unit:
 ifndef JUNITFILE
-	$(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) $(GO_TEST_PACKAGES)
+	$(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) $(GO_TEST_PACKAGES) $(GO_TEST_ARGS)
 else
 ifeq (, $(shell which gotest2junit 2>/dev/null))
 	$(error gotest2junit not found! Get it by `go get -mod='' -u github.com/openshift/release/tools/gotest2junit`.)
 endif
-	set -o pipefail; $(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) -json $(GO_TEST_PACKAGES) | gotest2junit > $(JUNITFILE)
+	set -o pipefail; $(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) -json $(GO_TEST_PACKAGES) $(GO_TEST_ARGS) | gotest2junit > $(JUNITFILE)
 endif
 .PHONY: test-unit


### PR DESCRIPTION
I have a use-case where I need to add test arguments in https://github.com/openshift/cluster-kube-apiserver-operator/pull/1449#discussion_r1120912655 and this is not possible today with the existing machinery since args need to be provided after the packages.