### PR TITLE
`vulncheck` for golang

### DIFF
--- a/make/default.example.mk.help.log
+++ b/make/default.example.mk.help.log
@@ -24,3 +24,4 @@ verify-gofmt
 verify-golang-versions
 verify-golint
 verify-govet
+vulncheck

--- a/make/golang.example.mk.help.log
+++ b/make/golang.example.mk.help.log
@@ -13,3 +13,4 @@ verify-gofmt
 verify-golang-versions
 verify-golint
 verify-govet
+vulncheck

--- a/make/operator.example.mk.help.log
+++ b/make/operator.example.mk.help.log
@@ -31,3 +31,4 @@ verify-golang-versions
 verify-golint
 verify-govet
 verify-profile-manifests
+vulncheck

--- a/make/targets/golang/vulncheck.mk
+++ b/make/targets/golang/vulncheck.mk
@@ -1,0 +1,31 @@
+scripts_dir :=$(shell realpath $(dir $(lastword $(MAKEFILE_LIST)))../../../scripts)
+
+# `make vulncheck` will emit a report similar to:
+# 
+# [
+#   "golang.org/x/net",
+#   "v0.5.0",
+#   "v0.7.0"
+# ]
+# [
+#   "stdlib",
+#   "go1.19.3",
+#   "go1.20.1"
+# ]
+# [
+#   "stdlib",
+#   "go1.19.3",
+#   "go1.19.4"
+# ]
+# 
+# Each stanza lists
+# - where the vulnerability exists
+# - the version it was found in
+# - the version it's fixed in
+# 
+# If the report contains any entries that are not in stdlib, the check
+# will fail (exit nonzero). Otherwise it will succeed -- i.e. the stdlib
+# entries are only warnings.
+vulncheck:
+	bash $(scripts_dir)/vulncheck.sh
+.PHONY: vulncheck

--- a/scripts/vulncheck.sh
+++ b/scripts/vulncheck.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+### Use govulncheck to check for known vulnerabilities in the project.
+### Fail if vulnerabilities are found in module dependencies.
+### Warn (but do not fail) on stdlib vulnerabilities.
+### TODO: Include useful information (ID, URL) about the vulnerability.
+
+go install golang.org/x/vuln/cmd/govulncheck@latest
+
+report=`mktemp`
+trap "rm $report" EXIT
+
+govulncheck -json ./... > $report
+
+modvulns=$(jq -r '.Vulns[].Modules[] | select(.Path != "stdlib") | [.Path, .FoundVersion, .FixedVersion]' < $report)
+libvulns=$(jq -r '.Vulns[].Modules[] | select(.Path == "stdlib") | [.Path, .FoundVersion, .FixedVersion]' < $report)
+
+echo "$modvulns"
+echo "$libvulns"
+
+# Exit nonzero iff there are any vulnerabilities in module dependencies
+test -z "$modvulns"


### PR DESCRIPTION
With this commit, `make vulncheck` will emit a report similar to:

```
[
  "golang.org/x/net",
  "v0.5.0",
  "v0.7.0"
]
[
  "stdlib",
  "go1.19.3",
  "go1.20.1"
]
[
  "stdlib",
  "go1.19.3",
  "go1.19.4"
]
```

Each stanza lists
- where the vulnerability exists
- the version it was found in
- the version it's fixed in

If the report contains any entries that are *not* in `stdlib`, the check will fail (exit nonzero). Otherwise it will succeed -- i.e. the `stdlib` entries are only warnings.

TODO: Include more useful information in each stanza, e.g. ID/URL.