### PR TITLE
Add commitchecker

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.17-openshift-4.10
+  tag: rhel-8-release-golang-1.20-openshift-4.14

--- a/Dockerfile.commitchecker
+++ b/Dockerfile.commitchecker
@@ -1,0 +1,14 @@
+# This Dockerfile must be on the top-level of this repo, because it needs to copy
+# both commitchecker/ and make/ into the build container.
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
+WORKDIR /go/src/github.com/openshift/build-machinery-go
+COPY . .
+RUN make -C commitchecker
+
+FROM registry.ci.openshift.org/ocp/4.14:base
+COPY --from=builder /go/src/github.com/openshift/build-machinery-go/commitchecker/commitchecker /usr/bin/
+RUN yum update -y && \
+    yum install --setopt=tsflags=nodocs -y git && \
+    yum clean all && rm -rf /var/cache/yum/*
+ENTRYPOINT ["/usr/bin/commitchecker"]

--- a/commitchecker/Makefile
+++ b/commitchecker/Makefile
@@ -1,0 +1,6 @@
+.PHONY: all
+all: build
+
+include $(addprefix ../make/, \
+        golang.mk \
+)

--- a/commitchecker/README.md
+++ b/commitchecker/README.md
@@ -1,0 +1,14 @@
+# commitchecker
+
+Cmdline tool that checks all commits in git branch or upstream PR have
+[format required by OpenShift for cherry-picks](https://github.com/openshift/kubernetes/blob/master/README.openshift.md#cherry-picking-an-upstream-change).
+
+## Usage
+
+```
+Usage of ./commitchecker:
+  -end string
+	The end of the revision range for analysis (default "HEAD")
+  -start string
+	The start of the revision range for analysis (default "master")
+```

--- a/commitchecker/cmd/commitchecker/main.go
+++ b/commitchecker/cmd/commitchecker/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/openshift/build-machinery-go/commitchecker/pkg/commitchecker"
+)
+
+func main() {
+	var start, end string
+	flag.StringVar(&start, "start", "master", "The start of the revision range for analysis")
+	flag.StringVar(&end, "end", "HEAD", "The end of the revision range for analysis")
+	flag.Parse()
+
+	commits, err := commitchecker.CommitsBetween(start, end)
+	if err != nil {
+		if err == commitchecker.ErrNotCommit {
+			_, _ = fmt.Fprintf(os.Stderr, "WARNING: one of the provided commits does not exist, not a true branch\n")
+			os.Exit(0)
+		}
+		_, _ = fmt.Fprintf(os.Stderr, "ERROR: couldn't find commits from %s..%s: %v\n", start, end, err)
+		os.Exit(1)
+	}
+
+	var errs []string
+	for _, validate := range commitchecker.AllCommitValidators {
+		for _, commit := range commits {
+			errs = append(errs, validate(commit)...)
+		}
+	}
+
+	if len(errs) > 0 {
+		for _, e := range errs {
+			_, _ = fmt.Fprintf(os.Stderr, "%s\n\n", e)
+		}
+
+		os.Exit(2)
+	}
+}

--- a/commitchecker/go.mod
+++ b/commitchecker/go.mod
@@ -1,0 +1,3 @@
+module github.com/openshift/build-machinery-go/commitchecker
+
+go 1.20

--- a/commitchecker/pkg/commitchecker/git.go
+++ b/commitchecker/pkg/commitchecker/git.go
@@ -1,0 +1,378 @@
+package commitchecker
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+var (
+	MergeSummaryPattern    = regexp.MustCompile(`^Merge commit .*`)
+	UpstreamSummaryPattern = regexp.MustCompile(`^UPSTREAM: (revert: )?(([\w\.-]+\/[\w-\.-]+)?: )?(\d+:|<carry>:|<drop>:)`)
+	BumpSummaryPattern     = regexp.MustCompile(`^bump[\(\w].*`)
+
+	// patchRegexps holds regexps for paths inside vendor dir that are allowed to be patched directly.
+	// It must corresponds to published repositories.
+	PatchRegexps = []*regexp.Regexp{
+		regexp.MustCompile("^k8s.io/kubernetes/.*"),
+	}
+
+	// supportedHosts maps source hosts to the number of path segments that
+	// represent the account/repo for that host. This is necessary because we
+	// can't tell just by looking at an import path whether the repo is identified
+	// by the first 2 or 3 path segments.
+	//
+	// If dependencies are introduced from new hosts, they'll need to be added
+	// here.
+	SupportedHosts = map[string]int{
+		"bitbucket.org":     3,
+		"cloud.google.com":  2,
+		"code.google.com":   3,
+		"github.com":        3,
+		"golang.org":        3,
+		"google.golang.org": 2,
+		"gopkg.in":          2,
+		"k8s.io":            2,
+		"speter.net":        2,
+	}
+)
+
+func RegexpsToStrings(a []*regexp.Regexp) []string {
+	var res []string
+	for _, r := range a {
+		res = append(res, r.String())
+	}
+	return res
+}
+
+type File string
+
+func (f File) HasVendoredCodeChanges() bool {
+	return strings.HasPrefix(string(f), "vendor")
+}
+
+func (f File) IsPatch() bool {
+	if !strings.HasPrefix(string(f), "vendor/") {
+		return false
+	}
+
+	for _, r := range PatchRegexps {
+		if r.Match([]byte(strings.TrimPrefix(string(f), "vendor/"))) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (f File) VendorRepo() (string, error) {
+	if !strings.HasPrefix(string(f), "vendor/") {
+		return "", fmt.Errorf("file %q doesn't appear to be a vendor change", string(f))
+	}
+
+	p := strings.TrimPrefix(string(f), "vendor/")
+
+	parts := strings.Split(p, string(os.PathSeparator))
+
+	if len(parts) < 1 {
+		return "", fmt.Errorf("invalid file %q", string(f))
+	}
+
+	numSegments, ok := SupportedHosts[parts[0]]
+	if !ok {
+		return "", fmt.Errorf("unsupported host for file %q", string(f))
+	}
+
+	if numSegments < 1 {
+		return "", fmt.Errorf("invalid number of segments %d when processing file path %q", numSegments, string(f))
+	}
+
+	return strings.Join(parts[0:numSegments], string(os.PathSeparator)), nil
+}
+
+type Commit struct {
+	Sha         string
+	Summary     string
+	Description []string
+	Files       []File
+	Email       string
+}
+
+func (c Commit) MatchesMergeSummaryPattern() bool {
+	return MergeSummaryPattern.MatchString(c.Summary)
+}
+
+func (c Commit) MatchesUpstreamSummaryPattern() bool {
+	return UpstreamSummaryPattern.MatchString(c.Summary)
+}
+
+func (c Commit) MatchesBumpSummaryPattern() bool {
+	return BumpSummaryPattern.MatchString(c.Summary)
+}
+
+func (c Commit) DeclaredUpstreamRepo() (string, error) {
+	if !c.MatchesUpstreamSummaryPattern() {
+		return "", fmt.Errorf("commit doesn't match the upstream commit summary pattern")
+	}
+	groups := UpstreamSummaryPattern.FindStringSubmatch(c.Summary)
+	repo := groups[3]
+	if len(repo) == 0 {
+		repo = "k8s.io/kubernetes"
+	}
+	return repo, nil
+}
+
+func (c Commit) HasVendoredCodeChanges() bool {
+	for _, file := range c.Files {
+		if file.HasVendoredCodeChanges() {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Commit) HasNonVendoredCodeChanges() bool {
+	for _, file := range c.Files {
+		if !file.HasVendoredCodeChanges() {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Commit) HasPatches() bool {
+	for _, f := range c.Files {
+		if f.IsPatch() {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Commit) HasBumpedFiles() bool {
+	for _, f := range c.Files {
+		if f.HasVendoredCodeChanges() && !f.IsPatch() {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Commit) PatchedRepos() ([]string, error) {
+	var repos []string
+	seenKeys := map[string]struct{}{}
+	for _, f := range c.Files {
+		if f.IsPatch() {
+			repo, err := f.VendorRepo()
+			if err != nil {
+				return nil, err
+			}
+			_, ok := seenKeys[repo]
+			if !ok {
+				repos = append(repos, repo)
+				seenKeys[repo] = struct{}{}
+			}
+		}
+	}
+	return repos, nil
+}
+
+func IsCommit(a string) bool {
+	if _, _, err := run("git", "rev-parse", a); err != nil {
+		return false
+	}
+	return true
+}
+
+var ErrNotCommit = fmt.Errorf("one or both of the provided commits was not a valid commit")
+
+func CommitsBetween(a, b string) ([]Commit, error) {
+	commits := []Commit{}
+	stdout, stderr, err := run("git", "log", "--oneline", fmt.Sprintf("%s..%s", a, b))
+	if err != nil {
+		if !IsCommit(a) || !IsCommit(b) {
+			return nil, ErrNotCommit
+		}
+		return nil, fmt.Errorf("error executing git log: %s: %s", stderr, err)
+	}
+	for _, log := range strings.Split(stdout, "\n") {
+		if len(log) == 0 {
+			continue
+		}
+		commit, err := NewCommitFromOnelineLog(log)
+		if err != nil {
+			return nil, err
+		}
+		commits = append(commits, commit)
+	}
+	return commits, nil
+}
+
+func NewCommitFromOnelineLog(log string) (Commit, error) {
+	var commit Commit
+	var err error
+	parts := strings.Split(log, " ")
+	if len(parts) < 2 {
+		return commit, fmt.Errorf("invalid log entry: %s", log)
+	}
+	commit.Sha = parts[0]
+	commit.Summary = strings.Join(parts[1:], " ")
+	commit.Description, err = descriptionInCommit(commit.Sha)
+	if err != nil {
+		return commit, err
+	}
+	files, err := filesInCommit(commit.Sha)
+	if err != nil {
+		return commit, err
+	}
+	commit.Files = files
+	commit.Email, err = emailInCommit(commit.Sha)
+	if err != nil {
+		return commit, err
+	}
+	return commit, nil
+}
+
+func FetchRepo(repoDir string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	defer os.Chdir(cwd)
+
+	if err := os.Chdir(repoDir); err != nil {
+		return err
+	}
+
+	if stdout, stderr, err := run("git", "fetch", "origin"); err != nil {
+		return fmt.Errorf("out=%s, err=%s, %s", strings.TrimSpace(stdout), strings.TrimSpace(stderr), err)
+	}
+	return nil
+}
+
+func IsAncestor(commit1, commit2, repoDir string) (bool, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return false, err
+	}
+	defer os.Chdir(cwd)
+
+	if err := os.Chdir(repoDir); err != nil {
+		return false, err
+	}
+
+	if stdout, stderr, err := run("git", "merge-base", "--is-ancestor", commit1, commit2); err != nil {
+		return false, fmt.Errorf("out=%s, err=%s, %s", strings.TrimSpace(stdout), strings.TrimSpace(stderr), err)
+	}
+
+	return true, nil
+}
+
+func CommitDate(commit, repoDir string) (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	defer os.Chdir(cwd)
+
+	if err := os.Chdir(repoDir); err != nil {
+		return "", err
+	}
+
+	if stdout, stderr, err := run("git", "fetch", "origin"); err != nil {
+		return "", fmt.Errorf("out=%s, err=%s, %s", strings.TrimSpace(stdout), strings.TrimSpace(stderr), err)
+	}
+
+	if stdout, stderr, err := run("git", "show", "-s", "--format=%ci", commit); err != nil {
+		return "", fmt.Errorf("out=%s, err=%s, %s", strings.TrimSpace(stdout), strings.TrimSpace(stderr), err)
+	} else {
+		return strings.TrimSpace(stdout), nil
+	}
+}
+
+func Checkout(commit, repoDir string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	defer os.Chdir(cwd)
+
+	if err := os.Chdir(repoDir); err != nil {
+		return err
+	}
+
+	if stdout, stderr, err := run("git", "checkout", commit); err != nil {
+		return fmt.Errorf("out=%s, err=%s, %s", strings.TrimSpace(stdout), strings.TrimSpace(stderr), err)
+	}
+	return nil
+}
+
+func CurrentRev(repoDir string) (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	defer os.Chdir(cwd)
+
+	if err := os.Chdir(repoDir); err != nil {
+		return "", err
+	}
+
+	if stdout, stderr, err := run("git", "rev-parse", "HEAD"); err != nil {
+		return "", fmt.Errorf("out=%s, err=%s, %s", strings.TrimSpace(stdout), strings.TrimSpace(stderr), err)
+	} else {
+		return strings.TrimSpace(stdout), nil
+	}
+}
+
+func emailInCommit(sha string) (string, error) {
+	stdout, stderr, err := run("git", "show", `--format=%ae`, "-s", sha)
+	if err != nil {
+		return "", fmt.Errorf("%s: %s", stderr, err)
+	}
+	return strings.TrimSpace(stdout), nil
+}
+
+func filesInCommit(sha string) ([]File, error) {
+	files := []File{}
+	stdout, stderr, err := run("git", "diff-tree", "--no-commit-id", "--name-only", "-r", sha)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %s", stderr, err)
+	}
+	for _, filename := range strings.Split(stdout, "\n") {
+		if len(filename) == 0 {
+			continue
+		}
+		files = append(files, File(filename))
+	}
+	return files, nil
+}
+
+func descriptionInCommit(sha string) ([]string, error) {
+	descriptionLines := []string{}
+	stdout, stderr, err := run("git", "log", "--pretty=%b", "-1", sha)
+	if err != nil {
+		return descriptionLines, fmt.Errorf("%s: %s", stderr, err)
+	}
+
+	for _, commitLine := range strings.Split(stdout, "\n") {
+		if len(commitLine) == 0 {
+			continue
+		}
+		descriptionLines = append(descriptionLines, commitLine)
+	}
+	return descriptionLines, nil
+}
+
+func run(args ...string) (string, string, error) {
+	cmd := exec.Command(args[0], args[1:]...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
+}

--- a/commitchecker/pkg/commitchecker/git_test.go
+++ b/commitchecker/pkg/commitchecker/git_test.go
@@ -1,0 +1,55 @@
+package commitchecker
+
+import (
+	"testing"
+)
+
+func TestUpstreamSummaryPattern(t *testing.T) {
+	tt := []struct {
+		summary string
+		valid   bool
+	}{
+		{valid: true, summary: "UPSTREAM: 12345: a change"},
+		{valid: true, summary: "UPSTREAM: k8s.io/heapster: 12345: a change"},
+		{valid: true, summary: "UPSTREAM: <carry>: a change"},
+		{valid: true, summary: "UPSTREAM: <drop>: a change"},
+		{valid: true, summary: "UPSTREAM: coreos/etcd: <carry>: a change"},
+		{valid: true, summary: "UPSTREAM: coreos/etcd: <drop>: a change"},
+		{valid: true, summary: "UPSTREAM: revert: 12345: a change"},
+		{valid: true, summary: "UPSTREAM: revert: k8s.io/heapster: 12345: a change"},
+		{valid: true, summary: "UPSTREAM: revert: <carry>: a change"},
+		{valid: true, summary: "UPSTREAM: revert: <drop>: a change"},
+		{valid: true, summary: "UPSTREAM: revert: coreos/etcd: <carry>: a change"},
+		{valid: true, summary: "UPSTREAM: revert: coreos/etcd: <drop>: a change"},
+		{valid: false, summary: "UPSTREAM: whoopsie daisy"},
+		{valid: true, summary: "UPSTREAM: gopkg.in/ldap.v2: 51: exposed better API for paged search"},
+	}
+	for _, tc := range tt {
+		t.Run(tc.summary, func(t *testing.T) {
+			got := UpstreamSummaryPattern.Match([]byte(tc.summary))
+
+			if tc.valid != got {
+				t.Errorf("expected %#v, got %#v", tc.valid, got)
+			}
+		})
+	}
+}
+
+func TestBumpPattern(t *testing.T) {
+	tt := []struct {
+		summary string
+		valid   bool
+	}{
+		{valid: true, summary: "bump(*)"},
+		{valid: false, summary: "not a bump"},
+	}
+	for _, tc := range tt {
+		t.Run(tc.summary, func(t *testing.T) {
+			got := BumpSummaryPattern.Match([]byte(tc.summary))
+
+			if tc.valid != got {
+				t.Errorf("expected %#v, got %#v", tc.valid, got)
+			}
+		})
+	}
+}

--- a/commitchecker/pkg/commitchecker/validate.go
+++ b/commitchecker/pkg/commitchecker/validate.go
@@ -1,0 +1,82 @@
+package commitchecker
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+	"text/template"
+)
+
+var (
+	// AllCommitValidators holds all registered checks.
+	AllCommitValidators = []func(Commit) []string{
+		ValidateCommitAuthor,
+
+		// Local commit messages must be prefixed with UPSTREAM as per
+		// README.openshift.md to aid in rebasing on upstream kube.
+		ValidateCommitMessage,
+	}
+)
+
+func ValidateCommitAuthor(commit Commit) []string {
+	var allErrors []string
+
+	if strings.HasPrefix(commit.Email, "root@") {
+		allErrors = append(allErrors, fmt.Sprintf("Commit %s has invalid email %q", commit.Sha, commit.Email))
+	}
+
+	return allErrors
+}
+
+func ValidateCommitMessage(commit Commit) []string {
+	if commit.MatchesMergeSummaryPattern() {
+		// Ignore merges
+		return nil
+	}
+
+	var allErrors []string
+
+	if !commit.MatchesUpstreamSummaryPattern() {
+		tmpl, _ := template.New("problems").Parse(`
+UPSTREAM commit {{ .Commit.Sha }} has invalid summary {{ .Commit.Summary }}.
+
+UPSTREAM commits are validated against the following regular expression:
+  {{ .Pattern }}
+
+UPSTREAM commit summaries should look like:
+
+  UPSTREAM: <PR number|carry|drop>: description
+
+UPSTREAM commits which revert previous UPSTREAM commits should look like:
+
+  UPSTREAM: revert: <normal upstream format>
+
+Examples of valid summaries:
+
+  UPSTREAM: 12345: A kube fix
+  UPSTREAM: <carry>: A carried kube change
+  UPSTREAM: <drop>: A dropped kube change
+  UPSTREAM: revert: 12345: A kube revert
+`)
+		data := struct {
+			Pattern *regexp.Regexp
+			Commit  Commit
+		}{
+			Pattern: UpstreamSummaryPattern,
+			Commit:  commit,
+		}
+		buffer := &bytes.Buffer{}
+		err := tmpl.Execute(buffer, data)
+		if err != nil {
+			allErrors = append(allErrors, err.Error())
+			return allErrors
+		}
+
+		allErrors = append(allErrors, buffer.String())
+
+		return allErrors
+	}
+
+	return allErrors
+}

--- a/commitchecker/pkg/commitchecker/validate_test.go
+++ b/commitchecker/pkg/commitchecker/validate_test.go
@@ -1,0 +1,94 @@
+package commitchecker
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestValidateCommitAuthor(t *testing.T) {
+	tt := []struct {
+		name         string
+		commit       Commit
+		expectedErrs []string
+	}{
+		{
+			name: "fails on root@locahost",
+			commit: Commit{
+				Sha:     "aaa0000",
+				Summary: "a summary",
+				Files: []File{
+					"README.md",
+				},
+				Email: "root@localhost",
+			},
+			expectedErrs: []string{
+				"Commit aaa0000 has invalid email \"root@localhost\"",
+			},
+		},
+		{
+			name: "succeeds for deads2k@redhat.com",
+			commit: Commit{
+				Sha:     "aaa0000",
+				Summary: "a summary",
+				Files: []File{
+					"README.md",
+				},
+				Email: "deads2k@redhat.com",
+			},
+			expectedErrs: nil,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErrs := ValidateCommitAuthor(tc.commit)
+			if !reflect.DeepEqual(tc.expectedErrs, gotErrs) {
+				t.Errorf("expected %#v, got %#v", tc.expectedErrs, gotErrs)
+			}
+		})
+	}
+}
+
+func TestValidateCommitMessage(t *testing.T) {
+	tt := []struct {
+		name         string
+		commit       Commit
+		expectedErrs []string
+	}{
+		{
+			name: "modifying k8s without UPSTREAM commit fails",
+			commit: Commit{
+				Sha:     "aaa0000",
+				Summary: "wrong summary",
+				Files: []File{
+					"README.md",
+					"pkg/controller/deployment/deployment.go",
+				},
+			},
+			expectedErrs: []string{
+				"\nUPSTREAM commit aaa0000 has invalid summary wrong summary.\n\nUPSTREAM commits are validated against the following regular expression:\n  ^UPSTREAM: (revert: )?(([\\w\\.-]+\\/[\\w-\\.-]+)?: )?(\\d+:|<carry>:|<drop>:)\n\nUPSTREAM commit summaries should look like:\n\n  UPSTREAM: <PR number|carry|drop>: description\n\nUPSTREAM commits which revert previous UPSTREAM commits should look like:\n\n  UPSTREAM: revert: <normal upstream format>\n\nExamples of valid summaries:\n\n  UPSTREAM: 12345: A kube fix\n  UPSTREAM: <carry>: A carried kube change\n  UPSTREAM: <drop>: A dropped kube change\n  UPSTREAM: revert: 12345: A kube revert\n",
+			},
+		},
+		{
+			name: "modifying k8s with UPSTREAM commit succeeds",
+			commit: Commit{
+				Sha:     "aaa0000",
+				Summary: "UPSTREAM: 42: Fix kube",
+				Files: []File{
+					"README.md",
+					"pkg/controller/deployment/deployment.go",
+				},
+			},
+			expectedErrs: nil,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErrs := ValidateCommitMessage(tc.commit)
+			if !reflect.DeepEqual(tc.expectedErrs, gotErrs) {
+				t.Errorf("expected %#v, got %#v", tc.expectedErrs, gotErrs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Moving it from
https://github.com/openshift/kubernetes/tree/master/openshift-hack/commitchecker ("o/k") to this repo, so it can be used outside of openshift/kubernetes.

The code is the same as in o/k, I just reworked it to `cmd/` and `pkg/` dirs that are expected by the makefiles in this repo.

Goal: Have a simple CI job that checks commits of a PR **without any changes in the repo** - it will be a fork for some upstream repository, something like o/k, and I do not want to carry any Makefiles or vendored deps with the commitchecker there.

Example of such CI job: 

```yaml
- as: verify-commits
  commands: |
    commitchecker --start ${PULL_BASE_SHA:-master}
  container:
    clone: true
    from: commitchecker
```