### PR TITLE
commitchecker: more updates

### DIFF
--- a/Dockerfile.commitchecker
+++ b/Dockerfile.commitchecker
@@ -6,9 +6,9 @@ WORKDIR /go/src/github.com/openshift/build-machinery-go
 COPY . .
 RUN make -C commitchecker
 
-FROM registry.ci.openshift.org/ocp/4.14:base
+FROM registry.ci.openshift.org/ocp/4.15:base
 COPY --from=builder /go/src/github.com/openshift/build-machinery-go/commitchecker/commitchecker /usr/bin/
-RUN yum update -y && \
-    yum install --setopt=tsflags=nodocs -y git && \
-    yum clean all && rm -rf /var/cache/yum/*
+RUN dnf update -y && \
+    dnf install --setopt=tsflags=nodocs -y git && \
+    dnf clean all && rm -rf /var/cache/yum/*
 ENTRYPOINT ["/usr/bin/commitchecker"]

--- a/Dockerfile.commitchecker
+++ b/Dockerfile.commitchecker
@@ -8,7 +8,6 @@ RUN make -C commitchecker
 
 FROM registry.ci.openshift.org/ocp/4.15:base
 COPY --from=builder /go/src/github.com/openshift/build-machinery-go/commitchecker/commitchecker /usr/bin/
-RUN dnf update -y && \
-    dnf install --setopt=tsflags=nodocs -y git && \
+RUN dnf install --setopt=tsflags=nodocs -y git && \
     dnf clean all && rm -rf /var/cache/yum/*
 ENTRYPOINT ["/usr/bin/commitchecker"]

--- a/commitchecker/.gitignore
+++ b/commitchecker/.gitignore
@@ -1,0 +1,1 @@
+commitchecker

--- a/commitchecker/commitchecker.go
+++ b/commitchecker/commitchecker.go
@@ -33,6 +33,7 @@ func main() {
 	}
 	start := opts.Start
 	if mergeBase != "" {
+		_, _ = fmt.Fprintf(os.Stdout, "Determined merge-base with %s/%s@%s at %s\n", cfg.UpstreamOrg, cfg.UpstreamRepo, cfg.UpstreamBranch, mergeBase)
 		start = mergeBase
 	}
 
@@ -46,6 +47,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	_, _ = fmt.Fprintf(os.Stdout, "Validating %d commits between %s...%s\n", len(commits), start, opts.End)
 	var errs []string
 	for _, validate := range commitchecker.AllCommitValidators {
 		for _, commit := range commits {

--- a/commitchecker/commitchecker.go
+++ b/commitchecker/commitchecker.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"os"
 
-	commitchecker2 "github.com/openshift/build-machinery-go/commitchecker/pkg/commitchecker"
+	"github.com/openshift/build-machinery-go/commitchecker/pkg/commitchecker"
 	"github.com/openshift/build-machinery-go/commitchecker/pkg/version"
 )
 
 func main() {
 	_, _ = fmt.Fprintf(os.Stdout, "commitchecker verson %v\n", version.Get().String())
-	opts := commitchecker2.DefaultOptions()
+	opts := commitchecker.DefaultOptions()
 	opts.Bind(flag.CommandLine)
 	flag.Parse()
 
@@ -20,13 +20,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	cfg, err := commitchecker2.Load(opts.ConfigFile)
+	cfg, err := commitchecker.Load(opts.ConfigFile)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "ERROR: couldn't load config: %v\n", err)
 		os.Exit(1)
 	}
 
-	mergeBase, err := commitchecker2.DetermineMergeBase(cfg, commitchecker2.FetchMode(opts.FetchMode), opts.End)
+	mergeBase, err := commitchecker.DetermineMergeBase(cfg, commitchecker.FetchMode(opts.FetchMode), opts.End)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "ERROR: couldn't determine merge base: %v\n", err)
 		os.Exit(1)
@@ -36,9 +36,9 @@ func main() {
 		start = mergeBase
 	}
 
-	commits, err := commitchecker2.CommitsBetween(start, opts.End)
+	commits, err := commitchecker.CommitsBetween(start, opts.End)
 	if err != nil {
-		if err == commitchecker2.ErrNotCommit {
+		if err == commitchecker.ErrNotCommit {
 			_, _ = fmt.Fprintf(os.Stderr, "WARNING: one of the provided commits does not exist, not a true branch\n")
 			os.Exit(0)
 		}
@@ -47,7 +47,7 @@ func main() {
 	}
 
 	var errs []string
-	for _, validate := range commitchecker2.AllCommitValidators {
+	for _, validate := range commitchecker.AllCommitValidators {
 		for _, commit := range commits {
 			errs = append(errs, validate(commit)...)
 		}

--- a/commitchecker/pkg/commitchecker/git.go
+++ b/commitchecker/pkg/commitchecker/git.go
@@ -38,7 +38,7 @@ var ErrNotCommit = fmt.Errorf("one or both of the provided commits was not a val
 
 func CommitsBetween(a, b string) ([]Commit, error) {
 	var commits []Commit
-	stdout, stderr, err := run("git", "log", "--no-merges", "--oneline", fmt.Sprintf("%s..%s", a, b))
+	stdout, stderr, err := run("git", "log", "--no-merges", "--oneline", "--ancestry-path", fmt.Sprintf("%s..%s", a, b))
 	if err != nil {
 		if !IsCommit(a) || !IsCommit(b) {
 			return nil, ErrNotCommit


### PR DESCRIPTION
commitchecker: don't use an import alias

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

commitchecker: log what we're doing

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

commitchecker: use the ancestry-path

After we do our merge magic to reset the repo to the upstream state,
`git log` requires `--ancestry-path` to output meaningful data.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

commitchecker: ignore built binary

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

