### PR TITLE
Only use MAJOR.MINOR version for go version from go.mod

### DIFF
--- a/make/targets/golang/version.mk
+++ b/make/targets/golang/version.mk
@@ -43,7 +43,7 @@ $(call verify-golang-version-reference,$(1),$(shell grep "AS builder" "$(1)" | s
 endef
 
 define verify-go-mod-golang-version
-$(call verify-golang-version-reference,go.mod,$(shell grep -e 'go [[:digit:]]*\.[[:digit:]]*' go.mod 2>/dev/null | sed 's/go //'))
+$(call verify-golang-version-reference,go.mod,$(shell grep -e 'go [[:digit:]]*\.[[:digit:]]*' go.mod 2>/dev/null | sed 's/go \([[:digit:]][[:digit:]]*.[[:digit:]][[:digit:]]*\).*/\1/'))
 endef
 
 define verify-buildroot-golang-version


### PR DESCRIPTION
Starting go 1.22, the go version in go.mod is formatted as MAJOR.MINOR.PATCH. For the purpose of verifying go version across go.mod, Dockerfile, ci-operator.yaml, only MAJOR.MINOR version is evaluated given go version in image tags from Docker and CI manifests are formatted as MAJOR.MAJOR only.