### PR TITLE
API-1835: Add -mod=readonly when installing mom

### DIFF
--- a/scripts/test-operator-integration.sh
+++ b/scripts/test-operator-integration.sh
@@ -8,7 +8,7 @@ set -x
 # Install multi-operator-manager. This will make sure the latest binary is installed
 # If the installation failed, keep going, maybe the binary is available in the system
 echo "Installing latest version of multi-operator-manager..."
-if ! go install github.com/openshift/multi-operator-manager/cmd/multi-operator-manager@latest; then
+if ! go install -mod=readonly github.com/openshift/multi-operator-manager/cmd/multi-operator-manager@latest; then
     echo "Error: Failed to install multi-operator-manager."
 fi
 


### PR DESCRIPTION
This is required because **-mod=vendor** is enforced in CI, so it tries to use the vendor directory for dependencies instead of fetching them from the internet.

Enforcing **-mod=readonly** means that the go command will ignore the vendor directory.

/assign @p0lyn0mial @deads2k 