### PR TITLE
Make images.mk generic

### DIFF
--- a/make/targets/openshift/images.mk
+++ b/make/targets/openshift/images.mk
@@ -7,15 +7,21 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 # make images IMAGE_BUILD_EXTRA_FLAGS='-mount ~/projects/origin-repos/4.2/:/etc/yum.repos.d/'
 IMAGE_BUILD_DEFAULT_FLAGS ?=--allow-pull
 IMAGE_BUILD_EXTRA_FLAGS ?=
+IMAGE_BUILD_BUILDER ?= imagebuilder
 
 # $1 - target name
 # $2 - image ref
 # $3 - Dockerfile path
 # $4 - context
+# only run ensure-imagebuilder when imagebuilder is used
 define build-image-internal
+ifeq ($(IMAGE_BUILD_BUILDER),imagebuilder)
 image-$(1): ensure-imagebuilder
+else
+image-$(1):
+endif
 	$(strip \
-		imagebuilder \
+		$(IMAGE_BUILD_BUILDER) \
 		$(IMAGE_BUILD_DEFAULT_FLAGS) \
 		-t $(2)
 		-f $(3) \


### PR DESCRIPTION
Make images.mk generic and not tied to imagebuilder. This will allow users to use other build tools such as podman and buildah.