### PR TITLE
Deprecate controller-gen.mk

### DIFF
--- a/make/targets/openshift/controller-gen.mk
+++ b/make/targets/openshift/controller-gen.mk
@@ -3,6 +3,26 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 	../../lib/tmp.mk \
 )
 
+##############
+# DEPRECATED #
+##############
+# This utility is hard to maintain due to the need to continuously build and release binaries for
+# multiple platforms and versions. Instead it is recommended that you:
+# - Vendor the sigs.k8s.io/controller-tools repository.
+# - Write a local rule to (lazily) build the controller-gen binary from the vendored repo.
+# For example:
+#
+# CONTROLLER_GEN_SRC := $(shell realpath vendor/sigs.k8s.io/controller-tools/cmd/controller-gen)
+# CONTROLLER_GEN := $(shell go list -f '{{.Target}}' $(CONTROLLER_GEN_SRC))
+# $(CONTROLLER_GEN): $(CONTROLLER_GEN_SRC)
+# 	go install $(CONTROLLER_GEN_SRC)
+#
+# This allows you to upgrade versions simply by revendoring controller-tools:
+# - Bump the semver in your go.mod
+# - go mod tidy
+# - go mod vendor
+##############
+
 # NOTE: The release binary specified here needs to be built properly so that
 # `--version` works correctly. Just using `go build` will result in it
 # reporting `(devel)`. To build for a given platform:


### PR DESCRIPTION
Though well-intentioned, controller-gen.mk is tough to maintain due to the need to build and publish binaries for multiple platforms at any desired release.

This PR does not change functionality, but leaves a deprecation comment in the source file with the idea that current consumers wishing to upgrade their controller-gen will find it after running into the same problems I did (see the issue).

Resolves #93