### PR TITLE
Update yq_dir var to recursively expand type in yq target

### DIFF
--- a/make/targets/openshift/yq.mk
+++ b/make/targets/openshift/yq.mk
@@ -8,8 +8,7 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 
 YQ_VERSION ?=2.4.0
 YQ ?=$(PERMANENT_TMP_GOPATH)/bin/yq-$(YQ_VERSION)
-yq_dir :=$(dir $(YQ))
-
+yq_dir =$(dir $(YQ))
 
 ensure-yq:
 ifeq "" "$(wildcard $(YQ))"


### PR DESCRIPTION
`yq_dir` variable in helper `yq` target is defined as simple expand type, which get evaluated only in the first occurrence and value set to `YQ` is not used for creating the target directory, but instead creates with default value.

```
Installing yq into '/home/bhb/WORKSPACE/src/github.com/openshift/external-secrets-operator/bin/yq'
mkdir -p '_output/tools/bin/'
curl -s -f -L https://github.com/mikefarah/yq/releases/download/v4.45.2/yq_linux_amd64 -o '/home/bhb/WORKSPACE/src/github.com/openshift/external-secrets-operator/bin/yq'
chmod +x '/home/bhb/WORKSPACE/src/github.com/openshift/external-secrets-operator/bin/yq';
```