### PR TITLE
(bugfix): Run gofmt on files in chunks

### DIFF
--- a/make/targets/golang/verify-update.mk
+++ b/make/targets/golang/verify-update.mk
@@ -3,11 +3,12 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 )
 
 go_files_count :=$(words $(GO_FILES))
+chunk_size :=1000
 
 verify-gofmt:
 	$(info Running `$(GOFMT) $(GOFMT_FLAGS)` on $(go_files_count) file(s).)
 	@TMP=$$( mktemp ); \
-	$(GOFMT) $(GOFMT_FLAGS) $(GO_FILES) | tee $${TMP}; \
+	echo $(GO_FILES) | xargs -n $(chunk_size) $(GOFMT) $(GOFMT_FLAGS) | tee $${TMP}; \
 	if [ -s $${TMP} ]; then \
 		echo "$@ failed - please run \`make update-gofmt\`"; \
 		exit 1; \
@@ -16,7 +17,7 @@ verify-gofmt:
 
 update-gofmt:
 	$(info Running `$(GOFMT) $(GOFMT_FLAGS) -w` on $(go_files_count) file(s).)
-	@$(GOFMT) $(GOFMT_FLAGS) -w $(GO_FILES)
+	@echo $(GO_FILES) | xargs -n $(chunk_size) $(GOFMT) $(GOFMT_FLAGS) -w
 .PHONY: update-gofmt
 
 


### PR DESCRIPTION
to prevent hitting the maximum argument limits when listing on an individual file basis.