### PR TITLE
(bugfix): use `find` command instead of `echo`-ing GO_FILES for verify and update targets

### DIFF
--- a/make/targets/golang/verify-update.mk
+++ b/make/targets/golang/verify-update.mk
@@ -8,7 +8,7 @@ chunk_size :=1000
 verify-gofmt:
 	$(info Running `$(GOFMT) $(GOFMT_FLAGS)` on $(go_files_count) file(s).)
 	@TMP=$$( mktemp ); \
-	echo $(GO_FILES) | xargs -n $(chunk_size) $(GOFMT) $(GOFMT_FLAGS) | tee $${TMP}; \
+	find . -name '*.go' -not -path '*/vendor/*' -not -path '*/_output/*' -print | xargs -n $(chunk_size) $(GOFMT) $(GOFMT_FLAGS) | tee $${TMP}; \
 	if [ -s $${TMP} ]; then \
 		echo "$@ failed - please run \`make update-gofmt\`"; \
 		exit 1; \
@@ -17,7 +17,7 @@ verify-gofmt:
 
 update-gofmt:
 	$(info Running `$(GOFMT) $(GOFMT_FLAGS) -w` on $(go_files_count) file(s).)
-	@echo $(GO_FILES) | xargs -n $(chunk_size) $(GOFMT) $(GOFMT_FLAGS) -w
+	@find . -name '*.go' -not -path '*/vendor/*' -not -path '*/_output/*' -print | xargs -n $(chunk_size) $(GOFMT) $(GOFMT_FLAGS) -w
 .PHONY: update-gofmt
 
 


### PR DESCRIPTION
In #105 I made a mistake that didn't fix the issue in openshift/client-go#323 because I shifted the argument earlier in the chain to the `echo $(GO_FILES)` process.

Instead, we should just use the actual `find` command to pipe the file list to the `xargs` subprocess.

I had missed that there was a way to test in openshift/client-go with the CI container that is used and had a false positive re: success when running locally (MacOS). 🤦 