### PR TITLE
commitchecker: fix image tags in README

### DIFF
--- a/commitchecker/README.md
+++ b/commitchecker/README.md
@@ -41,10 +41,8 @@ base_images:
   commitchecker:
     name: commitchecker
     namespace: ci
-    tag: "4.14"  # use appropriate OCP branch
+    tag: "latest"
 ```
-
-Note that the `commitchecker` image is available only with tags `4.14` and newer.
 
 2. Add `verify-commits` presubmit CI job that clones your repository, applies the PR-under-test and runs `commitchecker` image with the git clone inside:
 


### PR DESCRIPTION
We stopped building individual images for each OCP branch. The commitchecker is now available with tag `latest` that should work with all OCP braches.

Example of usage: https://github.com/openshift/release/blob/a156c2b5993702463f56d17667aa23680bc13aaa/ci-operator/config/openshift/csi-driver-smb/openshift-csi-driver-smb-master.yaml#L2-L5