### PR TITLE
fix: prevent nil pointer dereference when config file is missing

### DIFF
--- a/commitchecker/commitchecker.go
+++ b/commitchecker/commitchecker.go
@@ -28,7 +28,11 @@ func main() {
 	}
 
 	_, _ = fmt.Fprintf(os.Stdout, "post-argument options: %+v\n", opts)
-	_, _ = fmt.Fprintf(os.Stdout, "config: %+v\n", cfg)
+	if cfg != nil {
+		_, _ = fmt.Fprintf(os.Stdout, "config: %+v\n", cfg)
+	} else {
+		_, _ = fmt.Fprintf(os.Stdout, "config: (no config file found)\n")
+	}
 
 	mergeBase, err := commitchecker.DetermineMergeBase(cfg, commitchecker.FetchMode(opts.FetchMode), opts.End)
 	if err != nil {
@@ -36,7 +40,7 @@ func main() {
 		os.Exit(1)
 	}
 	start := opts.Start
-	if mergeBase != "" {
+	if mergeBase != "" && cfg != nil {
 		_, _ = fmt.Fprintf(os.Stdout, "Determined merge-base with %s/%s@%s at %s\n", cfg.UpstreamOrg, cfg.UpstreamRepo, cfg.UpstreamBranch, mergeBase)
 		start = mergeBase
 	}


### PR DESCRIPTION
Fixed by AI Cursor.
## Problem

The commitchecker tool was panicking with a nil pointer dereference when the config file (`commitchecker.yaml`) was not present. This happened because:

1. The `Load` function returns `nil, nil` when the config file doesn't exist (expected behavior)
2. The code was trying to print the config without checking if it was nil first
3. There was also a potential issue where `cfg` fields were accessed without nil checks

## Solution

- Added nil check before printing config to prevent panic
- Added nil check before accessing cfg fields in merge-base logic  
- Gracefully handle missing config file with informative message

## Testing

- Built and tested the fix locally
- Confirmed the program no longer panics when config file is missing
- Program now displays "config: (no config file found)" instead of crashing

## Changes

- `commitchecker/commitchecker.go`: Added nil checks for config handling

Fixes the panic: `runtime error: invalid memory address or nil pointer dereference` at `commitchecker.go:31` when `commitchecker.yaml` is not present.