### PR TITLE
Add reusable targets for OpenShift test extensions

### DIFF
--- a/make/targets/openshift/test-suite.mk
+++ b/make/targets/openshift/test-suite.mk
@@ -1,0 +1,33 @@
+# OpenShift Test Suite targets
+#
+# This file provides common targets for running OpenShift test suites
+# across all operator repos that use the openshift-tests-extension framework.
+#
+# Usage in main Makefile:
+#   include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
+#       targets/openshift/test-suite.mk \
+#   )
+#
+#   TESTS_BINARY := my-operator-tests
+#   TESTS_DIR := ./cmd/my-operator-tests
+#
+# Required variables:
+#   TESTS_BINARY - Name of the test binary
+#   TESTS_DIR - Directory containing test code (e.g., ./cmd/my-operator-tests)
+
+# -------------------------------------------------------------------
+# Run test suite
+# -------------------------------------------------------------------
+.PHONY: run-suite
+run-suite:
+	@if [ -z "$(SUITE)" ]; then \
+		echo "Error: SUITE variable is required. Usage: make run-suite SUITE=<suite-name> [JUNIT_DIR=<dir>]"; \
+		exit 1; \
+	fi
+	@JUNIT_ARG=""; \
+	if [ -n "$(JUNIT_DIR)" ]; then \
+		mkdir -p "$(JUNIT_DIR)"; \
+		JUNIT_ARG="--junit-path=$(JUNIT_DIR)/junit.xml"; \
+	fi; \
+	"$(TESTS_DIR)/$(TESTS_BINARY)" run-suite $(SUITE) $$JUNIT_ARG
+

--- a/make/targets/openshift/test-suite.mk
+++ b/make/targets/openshift/test-suite.mk
@@ -1,6 +1,6 @@
 # OpenShift Test Suite targets
 #
-# This file provides common targets for running OpenShift test suites
+# This file provides common targets for building and managing OpenShift test suites
 # across all operator repos that use the openshift-tests-extension framework.
 #
 # Usage in main Makefile:
@@ -16,18 +16,12 @@
 #   TESTS_DIR - Directory containing test code (e.g., ./cmd/my-operator-tests)
 
 # -------------------------------------------------------------------
-# Run test suite
+# Build and move test binary to correct location
 # -------------------------------------------------------------------
-.PHONY: run-suite
-run-suite:
-	@if [ -z "$(SUITE)" ]; then \
-		echo "Error: SUITE variable is required. Usage: make run-suite SUITE=<suite-name> [JUNIT_DIR=<dir>]"; \
-		exit 1; \
+.PHONY: tests-ext-build
+tests-ext-build: build
+	@mkdir -p $(TESTS_DIR)
+	@if [ -f $(shell basename $(TESTS_DIR)) ] && [ ! -f $(TESTS_DIR)/$(TESTS_BINARY) ]; then \
+		mv $(shell basename $(TESTS_DIR)) $(TESTS_DIR)/$(TESTS_BINARY); \
 	fi
-	@JUNIT_ARG=""; \
-	if [ -n "$(JUNIT_DIR)" ]; then \
-		mkdir -p "$(JUNIT_DIR)"; \
-		JUNIT_ARG="--junit-path=$(JUNIT_DIR)/junit.xml"; \
-	fi; \
-	"$(TESTS_DIR)/$(TESTS_BINARY)" run-suite $(SUITE) $$JUNIT_ARG
 


### PR DESCRIPTION
This PR adds common Makefile targets for building and running OpenShift test extensions across all operator repos that use the openshift-tests-extension framework.

   This follows the same pattern established in PR #94 (@bertinatto's work for the MOM project), providing centralized build logic that eliminates code duplication across operator repositories.

   ## Changes

   - **make/targets/openshift/tests-extension.mk**: Common targets for test extensions following the cluster-kube-apiserver-operator pattern

   ## Pattern

   The test extension should be a regular Go command in the repo (typically in `cmd/<operator-name>-tests`) that gets built as part of the normal build process. This is the pattern used by cluster-kube-apiserver-operator.

   ## Targets Provided

   - `tests-ext-build`: Build test extension binary (depends on main build)
   - `tests-ext-update`: Update test metadata
   - `tests-ext-clean`: Clean test extension artifacts
   - `run-suite`: Run a specific test suite
   - `list-test-names`: List available test names
   - `verify-tests-ext-metadata`: Verify metadata is up to date

   ## Usage

   ### In repo main Makefile:
   ```makefile
   include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
       targets/openshift/tests-extension.mk \
   )

   TESTS_EXT_BINARY := my-operator-tests-ext
   TESTS_EXT_DIR := ./cmd/my-operator-tests
   TESTS_EXT_OUTPUT_DIR := ./cmd/my-operator-tests  # Optional, defaults to TESTS_EXT_DIR
   ```

   This will automatically provide all the test extension targets and hook into the `clean` target.

   ## Benefits

   - **DRY**: All repos share the same target logic - no duplication
   - **Consistency**: All test extensions built the same way
   - **Maintainability**: Bug fixes and improvements only need to be made once
   - **Simple adoption**: Just include the .mk file and set 2-3 variables

   ## Example Repos That Can Adopt This

   - cluster-kube-apiserver-operator
   - cluster-authentication-operator
   - cluster-openshift-apiserver-operator
   - And others using openshift-tests-extension

   ## Related Work

   - Similar to PR #94 (MOM project integration tests)
   - Follows the cluster-kube-apiserver-operator Makefile pattern