### PR TITLE
NOJIRA: Make buildDate ldflags configurable

### DIFF
--- a/make/lib/golang.mk
+++ b/make/lib/golang.mk
@@ -60,10 +60,15 @@ ifndef OS_GIT_VERSION
 	OS_GIT_VERSION = $(SOURCE_GIT_TAG)
 endif
 
+BUILD_DATE_FORMAT ?='%Y-%m-%dT%H:%M:%SZ'
+ifneq "$(DONT_CLOBBER_MY_GO_BUILD_CACHE_PLEASE)" ""
+BUILD_DATE_FORMAT ='%Y-%m-%d'
+endif
+
 define version-ldflags
 -X $(1).versionFromGit="$(OS_GIT_VERSION)" \
 -X $(1).commitFromGit="$(SOURCE_GIT_COMMIT)" \
 -X $(1).gitTreeState="$(SOURCE_GIT_TREE_STATE)" \
--X $(1).buildDate="$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')"
+-X $(1).buildDate="$(shell date -u +$(BUILD_DATE_FORMAT))"
 endef
 GO_LD_FLAGS ?=-ldflags "$(call version-ldflags,$(GO_PACKAGE)/pkg/version) $(GO_LD_EXTRAFLAGS)"


### PR DESCRIPTION
I'm not sure who or what entity owns this repo, but here's the relevant card for hive: [HIVE-2907](https://redhat.atlassian.net/browse/HIVE-2907)

Using the full timestamp breaks go's build cache by changing every second. Using only the actual date (an expectation from the variable name itself) allows the cache to work, reducing incremental build times immensely:

Full clean build
```
real  1m31.099s
user  1m43.550s
sys   0m20.751s
```

Subsequent rebuilds with default date format
```
real  0m50.855s
user  1m5.162s
sys   0m12.172s
```

Subsequent rebuilds with fixed date format
```
real  0m3.642s
user  0m10.515s
sys   0m3.557s
```